### PR TITLE
Initial data export utility, sampling rate datatype change

### DIFF
--- a/notebook/data_export.ipynb
+++ b/notebook/data_export.ipynb
@@ -1,0 +1,434 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Data Export"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook outlines browsing of the database and use of the `pipeline.export` module to export recording data.\n",
+    "\n",
+    "The data format is a custom format used internally by project collaborators to support non-datajoint code, and supports export of processed per-probe electrophysiology data along with the experimental events pertaining to that data.\n",
+    "\n",
+    "If a session is known, the export capability is also available from the `mapshell.py` script; this usage will be documented below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Connecting chris@localhost:3306\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pipeline import lab\n",
+    "from pipeline import experiment\n",
+    "from pipeline import ephys\n",
+    "from pipeline import export"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Find Session / Probe Insertion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <style type=\"text/css\">\n",
+       "            .Relation{\n",
+       "                border-collapse:collapse;\n",
+       "            }\n",
+       "            .Relation th{\n",
+       "                background: #A0A0A0; color: #ffffff; padding:4px; border:#f0e0e0 1px solid;\n",
+       "                font-weight: normal; font-family: monospace; font-size: 100%;\n",
+       "            }\n",
+       "            .Relation td{\n",
+       "                padding:4px; border:#f0e0e0 1px solid; font-size:100%;\n",
+       "            }\n",
+       "            .Relation tr:nth-child(odd){\n",
+       "                background: #ffffff;\n",
+       "            }\n",
+       "            .Relation tr:nth-child(even){\n",
+       "                background: #f3f1ff;\n",
+       "            }\n",
+       "            /* Tooltip container */\n",
+       "            .djtooltip {\n",
+       "            }\n",
+       "            /* Tooltip text */\n",
+       "            .djtooltip .djtooltiptext {\n",
+       "                visibility: hidden;\n",
+       "                width: 120px;\n",
+       "                background-color: black;\n",
+       "                color: #fff;\n",
+       "                text-align: center;\n",
+       "                padding: 5px 0;\n",
+       "                border-radius: 6px;\n",
+       "                /* Position the tooltip text - see examples below! */\n",
+       "                position: absolute;\n",
+       "                z-index: 1;\n",
+       "            }\n",
+       "            #primary {\n",
+       "                font-weight: bold;\n",
+       "                color: black;\n",
+       "            }\n",
+       "\n",
+       "            #nonprimary {\n",
+       "                font-weight: normal;\n",
+       "                color: white;\n",
+       "            }\n",
+       "\n",
+       "            /* Show the tooltip text when you mouse over the tooltip container */\n",
+       "            .djtooltip:hover .djtooltiptext {\n",
+       "                visibility: visible;\n",
+       "            }\n",
+       "        </style>\n",
+       "        \n",
+       "        <b></b>\n",
+       "            <div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "            <table border=\"1\" class=\"Relation\">\n",
+       "                <thead> <tr style=\"text-align: right;\"> <th> <div class=\"djtooltip\">\n",
+       "                                <p id=\"primary\">subject_id</p>\n",
+       "                                <span class=\"djtooltiptext\">institution 6 digit animal ID</span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"primary\">session</p>\n",
+       "                                <span class=\"djtooltiptext\">session number</span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"nonprimary\">session_date</p>\n",
+       "                                <span class=\"djtooltiptext\"></span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"nonprimary\">username</p>\n",
+       "                                <span class=\"djtooltiptext\"></span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"nonprimary\">rig</p>\n",
+       "                                <span class=\"djtooltiptext\"></span>\n",
+       "                            </div> </th> </tr> </thead>\n",
+       "                <tbody> <tr> <td>435884</td>\n",
+       "<td>1</td>\n",
+       "<td>2018-12-07</td>\n",
+       "<td>daveliu</td>\n",
+       "<td>RRig</td> </tr> </tbody>\n",
+       "            </table>\n",
+       "            \n",
+       "            <p>Total: 1</p></div>\n",
+       "            "
+      ],
+      "text/plain": [
+       "*subject_id    *session    session_date   username     rig     \n",
+       "+------------+ +---------+ +------------+ +----------+ +------+\n",
+       "435884         1           2018-12-07     daveliu      RRig    \n",
+       " (Total: 1)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "experiment.Session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skey = {'subject_id': 435884, 'session': 1, 'session_date': '2018-12-07'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <style type=\"text/css\">\n",
+       "            .Relation{\n",
+       "                border-collapse:collapse;\n",
+       "            }\n",
+       "            .Relation th{\n",
+       "                background: #A0A0A0; color: #ffffff; padding:4px; border:#f0e0e0 1px solid;\n",
+       "                font-weight: normal; font-family: monospace; font-size: 100%;\n",
+       "            }\n",
+       "            .Relation td{\n",
+       "                padding:4px; border:#f0e0e0 1px solid; font-size:100%;\n",
+       "            }\n",
+       "            .Relation tr:nth-child(odd){\n",
+       "                background: #ffffff;\n",
+       "            }\n",
+       "            .Relation tr:nth-child(even){\n",
+       "                background: #f3f1ff;\n",
+       "            }\n",
+       "            /* Tooltip container */\n",
+       "            .djtooltip {\n",
+       "            }\n",
+       "            /* Tooltip text */\n",
+       "            .djtooltip .djtooltiptext {\n",
+       "                visibility: hidden;\n",
+       "                width: 120px;\n",
+       "                background-color: black;\n",
+       "                color: #fff;\n",
+       "                text-align: center;\n",
+       "                padding: 5px 0;\n",
+       "                border-radius: 6px;\n",
+       "                /* Position the tooltip text - see examples below! */\n",
+       "                position: absolute;\n",
+       "                z-index: 1;\n",
+       "            }\n",
+       "            #primary {\n",
+       "                font-weight: bold;\n",
+       "                color: black;\n",
+       "            }\n",
+       "\n",
+       "            #nonprimary {\n",
+       "                font-weight: normal;\n",
+       "                color: white;\n",
+       "            }\n",
+       "\n",
+       "            /* Show the tooltip text when you mouse over the tooltip container */\n",
+       "            .djtooltip:hover .djtooltiptext {\n",
+       "                visibility: visible;\n",
+       "            }\n",
+       "        </style>\n",
+       "        \n",
+       "        <b></b>\n",
+       "            <div style=\"max-height:1000px;max-width:1500px;overflow:auto;\">\n",
+       "            <table border=\"1\" class=\"Relation\">\n",
+       "                <thead> <tr style=\"text-align: right;\"> <th> <div class=\"djtooltip\">\n",
+       "                                <p id=\"primary\">subject_id</p>\n",
+       "                                <span class=\"djtooltiptext\">institution 6 digit animal ID</span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"primary\">session</p>\n",
+       "                                <span class=\"djtooltiptext\">session number</span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"primary\">insertion_number</p>\n",
+       "                                <span class=\"djtooltiptext\"></span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"nonprimary\">probe</p>\n",
+       "                                <span class=\"djtooltiptext\">unique identifier for this model of probe (e.g. part number)</span>\n",
+       "                            </div></th><th><div class=\"djtooltip\">\n",
+       "                                <p id=\"nonprimary\">electrode_config_name</p>\n",
+       "                                <span class=\"djtooltiptext\">user friendly name</span>\n",
+       "                            </div> </th> </tr> </thead>\n",
+       "                <tbody> <tr> <td>435884</td>\n",
+       "<td>1</td>\n",
+       "<td>1</td>\n",
+       "<td>15131808323</td>\n",
+       "<td>npx_first384</td> </tr> </tbody>\n",
+       "            </table>\n",
+       "            \n",
+       "            <p>Total: 1</p></div>\n",
+       "            "
+      ],
+      "text/plain": [
+       "*subject_id    *session    *insertion_num probe          electrode_conf\n",
+       "+------------+ +---------+ +------------+ +------------+ +------------+\n",
+       "435884         1           1              15131808323    npx_first384  \n",
+       " (Total: 1)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ephys.ProbeInsertion & skey"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ekey = {**skey, 'insertion_number': 1}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `export.export_recording` function is used to export data. Online help is available as follows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function export_recording in module pipeline.export:\n",
+      "\n",
+      "export_recording(insert_key, filepath=None)\n",
+      "    Export a 'recording' (probe specific data + related events) to a file.\n",
+      "    \n",
+      "    Parameters:\n",
+      "    \n",
+      "      - insert_key: an ephys.ProbeInsertion.primary_key\n",
+      "        currently: {'subject_id', 'session', 'insertion_number'})\n",
+      "    \n",
+      "      - filepath: an optional output file path string. If not provided,\n",
+      "        files will be created in the current directory using the 'mkfilename'\n",
+      "        function.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(export.export_recording)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function mkfilename in module pipeline.export:\n",
+      "\n",
+      "mkfilename(insert_key)\n",
+      "    create a filename for the given insertion key.\n",
+      "    filename will be of the format map-export_h2o_YYYY-MM-DD_SN_PN.mat\n",
+      "    \n",
+      "    where:\n",
+      "    \n",
+      "      - h2o: water restriction number\n",
+      "      - YYYY-MM-DD: session recording date\n",
+      "      - SN: session number for this subject\n",
+      "      - PN: probe number for this session\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(export.mkfilename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exporting {'subject_id': 435884, 'session': 1, 'session_date': '2018-12-07', 'insertion_number': 1} to map-export_dl59_2018-12-07_1_1.mat\n",
+      "fetching spike/behavior data\n",
+      "reshaping/processing for export\n",
+      "saving to map-export_dl59_2018-12-07_1_1.mat\n"
+     ]
+    }
+   ],
+   "source": [
+    "export.export_recording(ekey)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export Data (pipeline.shell - interactive)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `pipeline.shell` module wrapps the export_recording fuction - usage is as above:\n",
+    "\n",
+    "```\n",
+    "from pipeline import shell\n",
+    "shell.export_recording(ekey)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export Data (mapshell.py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To use the `export-recording` feature of the `mapshell.py` convenience script, pass in a quoted key and optional filename:\n",
+    "\n",
+    "\n",
+    "```\n",
+    "$ mapshell.py export-recording \"{'subject_id': 435884, 'session': 1, 'session_date': '2018-12-07', 'insertion_number': 1}\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pipeline/ephys.py
+++ b/pipeline/ephys.py
@@ -36,7 +36,7 @@ class ProbeInsertion(dj.Manual):
         definition = """
         -> master
         ---
-        sampling_rate: float  # (Hz)
+        sampling_rate: int  # (Hz)
         """
 
 

--- a/pipeline/export.py
+++ b/pipeline/export.py
@@ -1,0 +1,231 @@
+
+# Data Export for Druckmannlab
+
+import math
+
+import numpy as np
+import scipy.io as scio
+
+from pipeline import lab
+from pipeline import experiment
+from pipeline import ephys
+
+'''
+
+Notes:
+
+  - export includes behavior for trials without ephys data. how to handle?
+
+    if exclude, this means trial indices will be non-contiguous w/r/t database
+    if include, this means .mat cell arrays will vary by shape and need
+    handling locally.
+
+  - touch times: n/a - replace with?
+  - whisker angle: n/a - replace with?
+  - whisker distance to pole: n/a - replace with?
+  - pole on / off times: n/a - replace with?
+  - photostim starts at start of delay period.
+  - photostim model support:
+    a) we don't model on/off but start(variable w/r/t go)/duration(fixed)
+    b) start is modeled per trial
+    b) power is fixed per session
+
+'''
+
+
+def mkfilename(insert_key):
+    '''
+    create a filename for the given insertion key.
+    filename will be of the format map-export_h2o_YYYY-MM-DD_SN_PN.mat
+
+    where:
+
+      - h2o: water restriction number
+      - YYYY-MM-DD: session recording date
+      - SN: session number for this subject
+      - PN: probe number for this session
+
+    '''
+
+    fvars = ((lab.WaterRestriction * experiment.Session
+              * ephys.ProbeInsertion) & insert_key).fetch1()
+
+    return 'map-export_{}_{}_{}_{}.mat'.format(
+        fvars['water_restriction_number'], str(fvars['session_date']),
+        fvars['session'], fvars['insertion_number'])
+
+
+def export_recording(insert_key, filepath=None):
+    '''
+    Export a 'recording' (probe specific data + related events) to a file.
+
+    Parameters:
+
+      - insert_key: an ephys.ProbeInsertion.primary_key
+        currently: {'subject_id', 'session', 'insertion_number'})
+
+      - filepath: an optional output file path string. If not provided,
+        files will be created in the current directory using the 'mkfilename'
+        function.
+    '''
+
+    if not filepath:
+        filepath = mkfilename(insert_key)
+
+    print('exporting {} to {}'.format(insert_key, filepath))
+
+    print('fetching spike/behavior data')
+
+    insertion = (ephys.ProbeInsertion.InsertionLocation & insert_key).fetch1()
+    units = (ephys.Unit & insert_key).fetch()
+
+    # unit_trial = (ephys.Unit.UnitTrial & insert_key).fetch()  # trash?
+
+    trial_spikes = (ephys.TrialSpikes & insert_key).fetch()
+
+    behav = (experiment.BehaviorTrial & insert_key).fetch()
+    trials = behav['trial']
+
+    exports = ['neuron_single_units', 'neuron_unit_info', 'behavior_report',
+               'behavior_early_report', 'behavior_lick_times',
+               'task_trial_type', 'task_stimulation', 'task_cue_time']
+
+    edata = {k: None for k in exports}
+
+    print('reshaping/processing for export')
+
+    # neuron_single_units
+    # -------------------
+
+    # [[u0t0.spikes, ..., u0tN.spikes], ..., [uNt0.spikes, ..., uNtN.spikes]]
+
+    edata['neuron_single_units'] = np.array([
+        trial_spikes[np.where(trial_spikes['unit'] == u)]
+        for u in units['unit']])[0]['spike_times']
+
+    # neuron_unit_info
+    # ----------------
+    #
+    # [[depth_in_um, cell_type, recording_location] ...]
+
+
+    # from code import interact
+    # from collections import ChainMap
+    # interact('export_session',
+    #          local=dict(ChainMap(locals(), globals())))
+
+    dv = insertion['dv_location']
+    loc = insertion['brain_location_name']
+
+    types = (ephys.UnitCellType & insert_key).fetch()
+
+    _ui = []
+    for u in units:
+        if u['unit'] in types['unit']:
+            typ = types[np.where(types['unit'] == units[0]['unit'])][0]
+            _ui.append([u['unit_posy'] + dv, typ['cell_type'], loc])
+        else:
+            _ui.append([u['unit_posy'] + dv, 'unknown', loc])
+
+    edata['neuron_unit_info'] = np.array(_ui, dtype='O')
+
+    # behavior_report
+    # ---------------
+
+    behavior_report_map = {'hit': 1, 'miss': 0, 'ignore': 0}  # XXX: ignore ok?
+    edata['behavior_report'] = np.array([
+        behavior_report_map[i] for i in behav['outcome']])
+
+    # behavior_early_report
+    # ---------------------
+
+    early_report_map = {'early': 1, 'no early': 0}
+    edata['behavior_early_report'] = np.array([
+        early_report_map[i] for i in behav['early_lick']])
+
+    # behavior_touch_times
+    # --------------------
+
+    behavior_touch_times = None  # NOQA no data (see ActionEventType())
+
+    # behavior_lick_times
+    # -------------------
+
+    _lt = []
+    licks = (experiment.ActionEvent() & insert_key
+             & "action_event_type in ('left lick', 'right lick')").fetch()
+
+    for t in trials:
+
+        _lt.append([float(i) for i in   # decimal -> float
+                    licks[licks['trial'] == t]['action_event_time']]
+                   if t in licks['trial'] else [])
+
+    edata['behavior_lick_times'] = np.array(_lt)
+
+    behavior_whisker_angle = None  # NOQA no data
+    behavior_whisker_dist2pol = None  # NOQA no data
+
+    # task_trial_type
+    # ---------------
+
+    task_trial_type_map = {'left': 'l', 'right': 'r'}
+    edata['task_trial_type'] = np.array([
+        task_trial_type_map[i] for i in behav['trial_instruction']], dtype='O')
+
+    # task_stimulation
+    # ----------------
+
+    _ts = []  # [[power, type, on-time, off-time], ...]
+
+    photostim = (experiment.Photostim() & insert_key).fetch()
+
+    photostim_map = {}
+    photostim_dat = {}
+    photostim_keys = ['left_alm', 'right_alm', 'both_alm']
+    photostim_vals = [1, 2, 6]
+
+    # XXX: we don't detect duplicate presence of photostim_keys in data
+    for fk, rk in zip(photostim_keys, photostim_vals):
+
+        i = np.where(photostim['brain_location_name'] == fk)[0][0]
+        j = photostim[i]['photo_stim']
+        photostim_map[j] = rk
+        photostim_dat[j] = photostim[i]
+
+    photostim_ev = (experiment.PhotostimEvent & insert_key).fetch()
+
+    for t in trials:
+
+        if t in photostim_ev['trial']:
+
+            ev = photostim_ev[np.where(photostim_ev['trial'] == t)]
+            ps = photostim_map[ev['photo_stim'][0]]
+            pd = photostim_dat[ev['photo_stim'][0]]
+
+            _ts.append([float(ev['power']), ps,
+                        float(ev['photostim_event_time']),
+                        float(ev['photostim_event_time'] + pd['duration'])])
+
+        else:
+            _ts.append([0, math.nan, math.nan, math.nan])
+
+    edata['task_stimulation'] = np.array(_ts)
+
+    # task_pole_time
+    # --------------
+
+    task_pole_time = None  # NOQA no data
+
+    # task_cue_time
+    # -------------
+
+    _tct = (experiment.TrialEvent()
+            & {**insert_key, 'trial_event_type': 'go'}).fetch(
+                'trial_event_time')
+
+    edata['task_cue_time'] = np.array([float(i) for i in _tct])
+
+    print('saving to', filepath)
+
+    scio.savemat(filepath, edata)

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -15,6 +15,8 @@ from pipeline import histology
 from pipeline import tracking
 from pipeline import psth
 from pipeline import publication
+from pipeline import export
+
 
 pipeline_modules = [lab, ccf, experiment, ephys, histology, tracking, psth,
                     publication]
@@ -74,6 +76,9 @@ def populate_psth(*args):
     log.info('ephys.UnitStat.populate()')
     ephys.UnitStat.populate()
 
+    log.info('ephys.UnitCellType.populate()')
+    ephys.UnitCellType.populate()
+
     log.info('psth.UnitPsth.populate()')
     psth.UnitPsth.populate()
 
@@ -108,6 +113,12 @@ def publish(*args):
     publication.ArchivedRawEphysTrial.populate()
 
 
+def export_recording(*args):
+    ik = eval(args[0])  # "{k: v}" -> dict(k=v)
+    fn = args[1] if len(args) > 1 else None
+    export.export_recording(ik, fn)
+
+
 def shell(*args):
     interact('map shell.\n\nschema modules:\n\n  - {m}\n'
              .format(m='\n  - '.join(
@@ -135,6 +146,7 @@ actions = {
     'ingest-histology': ingest_histology,
     'populate-psth': populate_psth,
     'publish': publish,
+    'export-recording': export_recording,
     'shell': shell,
     'erd': erd,
     'ccfload': ccfload,

--- a/scripts/map-mock-data.py
+++ b/scripts/map-mock-data.py
@@ -17,6 +17,8 @@ from pipeline import lab
 from pipeline import ccf
 from pipeline import experiment
 from pipeline import ephys
+from pipeline import histology
+from pipeline import tracking
 from pipeline import publication
 from pipeline import get_schema_name
 
@@ -31,23 +33,25 @@ def usage_exit():
 def dropdbs():
     print('dropping databases')
     for d in ['ingest_histology', 'ingest_ephys', 'ingest_tracking',
-              'ingest_behavior', 'publication', 'psth', 'tracking', 'ephys',
-              'experiment', 'lab', 'ccf']:
+              'ingest_behavior', 'publication', 'psth', 'tracking',
+              'histology', 'ephys', 'experiment', 'ccf', 'lab']:
         dname = get_schema_name(d)
         print('..  {} ({})'.format(d, dname))
         try:
             schema = dj.schema(dname)
             schema.drop(force=True)
-        except:
-            pass
+        except Exception as e:
+            print("....  couldn't drop database {} : {}".format(d, repr(e)))
 
 
 def mockdata():
     print('populating with mock data')
-    reload(ccf)
     reload(lab)
+    reload(ccf)
     reload(experiment)
     reload(ephys)
+    reload(histology)
+    reload(tracking)
     reload(publication)
     try:
         # TODO: these should be loaded in a more 'official' way

--- a/scripts/map-mock-data.py
+++ b/scripts/map-mock-data.py
@@ -635,9 +635,9 @@ def post_ephys(*args):
                 'session': 1,
                 'insertion_number': 1,
                 'brain_location_name': 'right_alm',
-                # ml_location:
-                # ap_location:
-                # dv_location:
+                'ml_location': 1500,
+                'ap_location': 2500,
+                'dv_location': 1668.9,
                 # ml_angle:
                 # ap_angle:
             }
@@ -648,9 +648,9 @@ def post_ephys(*args):
                 'session': 1,
                 'insertion_number': 1,
                 'brain_location_name': 'right_medulla',
-                # ml_location:
-                # ap_location:
-                # dv_location:
+                'ml_location': 1000,
+                'ap_location': 6500,
+                'dv_location': 5237.5,
                 # ml_angle:
                 # ap_angle:
             }
@@ -660,6 +660,9 @@ def post_ephys(*args):
 
         ephys.ProbeInsertion.InsertionLocation().insert1(
             rec, skip_duplicates=True)
+        ephys.ProbeInsertion.RecordingSystemSetup().insert1(
+            {**rec, 'sampling_rate': 30000}, ignore_extra_fields=True,
+            skip_duplicates=True)
 
 
 def preload(*args):

--- a/scripts/mapshell.py
+++ b/scripts/mapshell.py
@@ -14,4 +14,4 @@ if __name__ == '__main__':
     shell.logsetup(os.environ.get('MAP_LOGLEVEL', 'INFO'))
 
     action = sys.argv[1]
-    shell.actions[action](sys.argv[2:])
+    shell.actions[action](*sys.argv[2:])


### PR DESCRIPTION
- Initial data export added in `pipeline/export.py`, notebook in `notebook/data_export.ipynb`

  Some standing questions based on reference file are noted at top of `pipeline/export.py`,
  these should be discussed/clarified

- ephys.ProbeInsertion.RecordingSystemSetup: ( a59bdc1 )

  - need to either drop downstream or alter in place.

    safest is drop; however alter shouldn't affect downstream computation here
    since 30k is 'safe' int:float round trip & value would likely be cast correctly.

    SQL:

      ```mysql> use map_v1_ephys;
      mysql> ALTER TABLE probe_insertion__recording_system_setup
             MODIFY COLUMN sampling_rate int;
     ```

    or via GUI.       