### PR TITLE
pipeline/ingest/behavior.py: drop RigDataPath; BehaviorFile now only filename

### DIFF
--- a/pipeline/ingest/behavior.py
+++ b/pipeline/ingest/behavior.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 
 import os
-import glob
 import logging
 import re
 import math
@@ -9,7 +8,6 @@ import pathlib
 
 from datetime import date
 from datetime import datetime
-from itertools import chain
 from collections import namedtuple
 
 import scipy.io as spio
@@ -18,7 +16,6 @@ import warnings
 
 import datajoint as dj
 
-from pipeline import ccf
 from pipeline import lab
 from pipeline import experiment
 from .. import get_schema_name
@@ -51,31 +48,23 @@ photostims = {4: {'photo_stim': 4, 'photostim_device': 'OBIS470', 'duration': ph
                                 ]}}
 
 
-@schema
-class RigDataPath(dj.Lookup):
-    ''' rig storage locations '''
-    # todo: cross platform path mapping needed?
-    definition = """
-    -> lab.Rig
-    ---
-    rig_data_path:              varchar(1024)           # rig data path
-    rig_search_order:           int                     # rig search order
-    """
+def get_behavior_paths():
+    '''
+    retrieve behavior rig paths from dj.config
+    config should be in dj.config of the format:
 
-    @property
-    def contents(self):
+      dj.config = {
+        ...,
+        'custom': {
+          'behavior_paths': {
+            'Rig1': '/path/string',
+          }
+        }
+        ...
+      }
 
-        custom_paths = dj.config.get('custom', {}).get('rig_data_paths', None)
-
-        if custom_paths:
-            return custom_paths
-
-        return (('TRig1', r'\\MOHARB-NUC1\Documents\Arduino\Bpod_Train1\Bpod Local\Data', 0),  # Hardcode the rig path
-                ('TRig2', r'\\MOHARB-WW2\C\Users\labadmin\Documents\MATLAB\Bpod Local\Data', 1),
-                ('TRig3', r'\\WANGT-NUC\Documents\MATLAB\Bpod Local\Data', 2),
-                ('RRig', r'\\wangt-ww1\Documents\MATLAB\Bpod Local\Data', 3),
-                ('RRig2', r'\\Yuj10-ww3\C\Bpod Local\Data', 4)
-                ) # A table with the data path
+    '''
+    return dj.config.get('custom', {}).get('behavior_paths', None)
 
 
 @schema
@@ -88,7 +77,7 @@ class BehaviorIngest(dj.Imported):
         ''' files in rig-specific storage '''
         definition = """
         -> BehaviorIngest
-        behavior_file:              varchar(255)          # rig file subpath
+        behavior_file:              varchar(255)          # behavior file name
         """
 
     class CorrectedTrialEvents(dj.Part):
@@ -171,23 +160,24 @@ class BehaviorIngest(dj.Imported):
         recs = []
         found = set()
         known = set(BehaviorIngest.BehaviorFile().fetch('behavior_file'))
-        rigs = RigDataPath().fetch(as_dict=True, order_by='rig_search_order')
-        for r in rigs:
-            rig = r['rig']
-            rigpath = pathlib.Path(r['rig_data_path'])
-            log.info('RigDataFile.make(): traversing {p}'.format(p=rigpath))
+        rigs = get_behavior_paths()
+
+        for rig in rigs:
+            rigpath = pathlib.Path(rigs[rig])
+
+            log.info('RigDataFile.make(): traversing {}'.format(rigpath))
             for root, dirs, files in os.walk(rigpath):
-                log.debug('RigDataFile.make(): entering {r}'.format(r=root))
+                log.debug('RigDataFile.make(): entering {}'.format(root))
                 for f in files:
-                    log.debug('RigDataFile.make(): visiting {f}'.format(f=f))
+                    log.debug('RigDataFile.make(): visiting {}'.format(f))
                     r = buildrec(rig, rigpath, root, f)
                     if not r:
                         continue
-                    if r['subpath'] in set.union(known, found):
+                    if f in set.union(known, found):
                         log.info('skipping already ingested file {}'.format(
                             r['subpath']))
                     else:
-                        found.add(r['subpath'])  # block duplicate path conf
+                        found.add(f)  # block duplicate path conf
                         recs.append(r)
 
         return recs
@@ -742,5 +732,5 @@ class BehaviorIngest(dj.Imported):
 
         log.info('BehaviorIngest.make(): ... BehaviorIngest.BehaviorFile')
         BehaviorIngest.BehaviorFile().insert1(
-            dict(key, behavior_file=str(key['subpath'])),
+            dict(key, behavior_file=os.path.basename(key['subpath'])),
             ignore_extra_fields=True, allow_direct_insert=True)


### PR DESCRIPTION
Moving to a more flexible path configuration due to updated assumptions
about lab/IT configuration.

RigDataPath is now dropped, ingest now comes exclusively through dj.config
with an updated/simplified format (see get_behavior_paths docstring).