### PR TITLE
Ingestion of spike_depths, hexcode for ontology regions, driftmap plot

### DIFF
--- a/pipeline/ephys.py
+++ b/pipeline/ephys.py
@@ -137,6 +137,8 @@ class Unit(dj.Imported):
     unit_posx : double # (um) estimated x position of the unit relative to probe's tip (0,0)
     unit_posy : double # (um) estimated y position of the unit relative to probe's tip (0,0)
     spike_times : longblob  # (s) from the start of the first data point used in clustering
+    spike_sites : longblob  # array of electrode associated with each spike
+    spike_depths : longblob # (um) array of depths associated with each spike
     unit_amp : double
     unit_snr : double
     waveform : blob # average spike waveform
@@ -388,6 +390,8 @@ class ArchivedClustering(dj.Imported):
         unit_posx : double # (um) estimated x position of the unit relative to probe's tip (0,0)
         unit_posy : double # (um) estimated y position of the unit relative to probe's tip (0,0)
         spike_times : blob@archive_store  # (s) from the start of the first data point used in clustering
+        spike_sites : blob@archive_store  # array of electrode associated with each spike
+        spike_depths : blob@archive_store # (um) array of depths associated with each spike
         trial_spike : blob@archive_store  # array of trial numbering per spike - same size as spike_times
         waveform : blob@archive_store     # average spike waveform  
         """

--- a/pipeline/fixes/fix_0010_spike_sites_and_spike_depths.py
+++ b/pipeline/fixes/fix_0010_spike_sites_and_spike_depths.py
@@ -1,0 +1,162 @@
+#! /usr/bin/env python
+
+import os
+import logging
+import pathlib
+from datetime import datetime
+from itertools import repeat
+import numpy as np
+import datajoint as dj
+
+from pipeline import lab, experiment, ephys
+
+from pipeline.ingest import ProbeInsertionError, ClusterMetricError
+from pipeline.ingest.ephys import (get_ephys_paths, cluster_loader_map,
+                                   _get_sess_dir, _match_probe_to_ephys, _gen_probe_insert)
+from pipeline.fixes import schema, FixHistory
+
+
+os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = "TRUE"
+
+log = logging.getLogger(__name__)
+
+
+@schema
+class AddSpikeSitesAndDepths(dj.Manual):
+    """
+    This table accompanies fix_0010, keeping track of the units with spike sites and spike depths added.
+    This tracking is not extremely important, as a rerun of this fix_0010 will still yield the correct results
+    """
+    definition = """ # This table accompanies fix_0010
+    -> FixHistory
+    -> ephys.Unit
+    ---
+    fixed: bool
+    """
+
+
+def update_spike_sites_and_depths(session_keys={}):
+    """
+    Updating unit-waveform, where a unit's waveform is updated to be from the peak-channel
+        and not from the 1-st channel as before
+    Applicable to only kilosort2 clustering results and not jrclust
+    """
+    sessions_2_update = experiment.Session & ephys.Unit & session_keys
+    sessions_2_update = sessions_2_update - AddSpikeSitesAndDepths
+
+    if not sessions_2_update:
+        return
+
+    fix_hist_key = {'fix_name': pathlib.Path(__file__).name,
+                    'fix_timestamp': datetime.now()}
+
+    for key in sessions_2_update.fetch('KEY'):
+        success = _update_one_session(key)
+        if success:
+            FixHistory.insert1(fix_hist_key, skip_duplicates=True)
+            AddSpikeSitesAndDepths.insert([{**fix_hist_key, **ukey, 'fixed': 1} for ukey in (ephys.Unit & key).fetch('KEY')])
+
+
+def _update_one_session(key):
+    log.info('\n======================================================')
+    log.info('Waveform update for key: {k}'.format(k=key))
+
+    #
+    # Find Ephys Recording
+    #
+    key = (experiment.Session & key).fetch1()
+    sinfo = ((lab.WaterRestriction
+              * lab.Subject.proj()
+              * experiment.Session.proj(..., '-session_time')) & key).fetch1()
+
+    rigpaths = get_ephys_paths()
+    h2o = sinfo['water_restriction_number']
+
+    sess_time = (datetime.min + key['session_time']).time()
+    sess_datetime = datetime.combine(key['session_date'], sess_time)
+
+    for rigpath in rigpaths:
+        dpath, dglob = _get_sess_dir(rigpath, h2o, sess_datetime)
+        if dpath is not None:
+            break
+
+    if dpath is not None:
+        log.info('Found session folder: {}'.format(dpath))
+    else:
+        log.warning('Error - No session folder found for {}/{}. Skipping...'.format(h2o, key['session_date']))
+        return False
+
+    try:
+        clustering_files = _match_probe_to_ephys(h2o, dpath, dglob)
+    except FileNotFoundError as e:
+        log.warning(str(e) + '. Skipping...')
+        return False
+
+    with ephys.Unit.connection.transaction:
+        for probe_no, (f, cluster_method, npx_meta) in clustering_files.items():
+            try:
+                log.info('------ Start loading clustering results for probe: {} ------'.format(probe_no))
+                loader = cluster_loader_map[cluster_method]
+                dj.conn().ping()
+                _add_spike_sites_and_depths(loader(sinfo, *f), probe_no, npx_meta, rigpath)
+            except (ProbeInsertionError, ClusterMetricError, FileNotFoundError) as e:
+                dj.conn().cancel_transaction()  # either successful fix of all probes, or none at all
+                if isinstance(e, ProbeInsertionError):
+                    log.warning('Probe Insertion Error: \n{}. \nSkipping...'.format(str(e)))
+                else:
+                    log.warning('Error: {}'.format(str(e)))
+                return False
+
+        with dj.config(safemode=False):
+            (ephys.UnitCellType & key).delete()
+
+    return True
+
+
+def _add_spike_sites_and_depths(data, probe, npx_meta, rigpath):
+
+    sinfo = data['sinfo']
+    skey = data['skey']
+    method = data['method']
+    spikes = data['spikes']
+    units = data['units']
+    vmax_unit_site = data['vmax_unit_site']
+    spike_sites = data['spike_sites']
+    spike_depths = data['spike_depths']
+
+    clustering_label = data['clustering_label']
+
+    log.info('-- Start insertions for probe: {} - Clustering method: {} - Label: {}'.format(probe, method,
+                                                                                            clustering_label))
+
+    # probe insertion key
+    insertion_key, e_config_key = _gen_probe_insert(sinfo, probe, npx_meta, probe_insertion_exists=True)
+
+    # remove noise clusters
+    if method in ['jrclust_v3', 'jrclust_v4']:
+        units, spikes, spike_sites, spike_depths = (v[i] for v, i in zip(
+            (units, spikes, spike_sites, spike_depths), repeat((units > 0))))
+
+    q_electrodes = lab.ProbeType.Electrode * lab.ElectrodeConfig.Electrode & e_config_key
+    site2electrode_map = {}
+    for recorded_site in np.unique(spike_sites):
+        shank, shank_col, shank_row, _ = npx_meta.shankmap['data'][recorded_site - 1]  # subtract 1 because npx_meta shankmap is 0-indexed
+        site2electrode_map[recorded_site] = (q_electrodes
+                                             & {'shank': shank + 1,  # this is a 1-indexed pipeline
+                                                'shank_col': shank_col + 1,
+                                                'shank_row': shank_row + 1}).fetch1('KEY')
+
+    spike_sites = np.array([site2electrode_map[s]['electrode'] for s in spike_sites])
+    unit_spike_sites = np.array([spike_sites[np.where(units == u)] for u in set(units)])
+    unit_spike_depths = np.array([spike_depths[np.where(units == u)] for u in set(units)])
+
+    # _update() on spike_sites and spike_depths
+    for i, u in enumerate(set(units)):
+        (ephys.Unit & {**skey, **insertion_key, 'clustering_method': method,
+                       'unit': u})._update('spike_sites', unit_spike_sites[i])
+        (ephys.Unit & {**skey, **insertion_key, 'clustering_method': method,
+                       'unit': u})._update('spike_depths', unit_spike_depths[i])
+
+
+if __name__ == '__main__':
+    update_spike_sites_and_depths()

--- a/pipeline/fixes/fix_0011_add_onto_id_and_hexcode.py
+++ b/pipeline/fixes/fix_0011_add_onto_id_and_hexcode.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python
+
+import logging
+
+import datajoint as dj
+import numpy as np
+import pathlib
+from datetime import datetime
+from tifffile import imread
+
+from pipeline import ccf
+from pipeline.fixes import FixHistory
+
+log = logging.getLogger(__name__)
+
+
+def add_ontology_region_id_and_hexcode():
+    """
+    Update to the ccf.CCFAnnotation table, udpating values for 2 new attributes:
+        + ontology_region_id
+        + color_code
+    """
+
+    fix_hist_key = {'fix_name': pathlib.Path(__file__).name,
+                    'fix_timestamp': datetime.now()}
+    FixHistory.insert1(fix_hist_key)
+
+    stack_path = dj.config['custom']['ccf.r3_20um_path']
+    stack = imread(stack_path)  # load reference stack
+
+    log.info('.. loaded stack of shape {} from {}'
+             .format(stack.shape, stack_path))
+
+    # iterate over ccf ontology region id/name records,
+    regions = ccf.CCFAnnotation().get_ccf_r3_20um_ontology_regions()
+    region, nregions = 0, len(regions)
+
+    for region_id, region_name, color_hexcode in regions:
+
+        region += 1
+        region_id = int(region_id)
+
+        log.info('.. loading region {} ({}/{}) ({})'
+                 .format(region_id, region, nregions, region_name))
+
+        # extracting filled volumes from stack in scaled [[x,y,z]] shape,
+        vol = np.array(np.where(stack == region_id)).T[:, [2, 1, 0]] * 20
+
+        if not vol.shape[0]:
+            log.info('.. region {} volume: shape {} - skipping'
+                     .format(region_id, vol.shape))
+            continue
+
+        log.info('.. region {} volume: shape {}'.format(region_id, vol.shape))
+
+        with dj.conn().transaction:
+            for vox in vol:
+                key = {'ccf_label_id': ccf.CCFLabel.CCF_R3_20UM_ID,
+                       'ccf_x': vox[0], 'ccf_y': vox[1], 'ccf_z': vox[2],
+                       'annotation_type': ccf.CCFLabel.CCF_R3_20UM_TYPE}
+                assert (ccf.CCFAnnotation & key).fetch1('annotation') == region_name
+                (ccf.CCFAnnotation & key)._update('ontology_region_id', region_id)
+                (ccf.CCFAnnotation & key)._update('color_code', color_hexcode)
+
+    log.info('.. done.')
+
+
+if __name__ == '__main__':
+    add_ontology_region_id_and_hexcode()

--- a/pipeline/reference/ccf_ontology.py
+++ b/pipeline/reference/ccf_ontology.py
@@ -1,1210 +1,1210 @@
 
 # Mouse CCF Ontology IDs/Names:
 ccf_ontology = '''
-997,root
-8,Basic cell groups and regions
-567,Cerebrum
-688,Cerebral cortex
-695,Cortical plate
-315,Isocortex
-184,"Frontal pole, cerebral cortex"
-68,"Frontal pole, layer 1"
-667,"Frontal pole, layer 2/3"
-500,Somatomotor areas
-107,"Somatomotor areas, Layer 1"
-219,"Somatomotor areas, Layer 2/3"
-299,"Somatomotor areas, Layer 5"
-644,"Somatomotor areas, Layer 6a"
-947,"Somatomotor areas, Layer 6b"
-985,Primary motor area
-320,"Primary motor area, Layer 1"
-943,"Primary motor area, Layer 2/3"
-648,"Primary motor area, Layer 5"
-844,"Primary motor area, Layer 6a"
-882,"Primary motor area, Layer 6b"
-993,Secondary motor area
-656,"Secondary motor area, layer 1"
-962,"Secondary motor area, layer 2/3"
-767,"Secondary motor area, layer 5"
-1021,"Secondary motor area, layer 6a"
-1085,"Secondary motor area, layer 6b"
-453,Somatosensory areas
-12993,"Somatosensory areas, layer 1"
-12994,"Somatosensory areas, layer 2/3"
-12995,"Somatosensory areas, layer 4"
-12996,"Somatosensory areas, layer 5"
-12997,"Somatosensory areas, layer 6a"
-12998,"Somatosensory areas, layer 6b"
-322,Primary somatosensory area
-793,"Primary somatosensory area, layer 1"
-346,"Primary somatosensory area, layer 2/3"
-865,"Primary somatosensory area, layer 4"
-921,"Primary somatosensory area, layer 5"
-686,"Primary somatosensory area, layer 6a"
-719,"Primary somatosensory area, layer 6b"
-353,"Primary somatosensory area, nose"
-558,"Primary somatosensory area, nose, layer 1"
-838,"Primary somatosensory area, nose, layer 2/3"
-654,"Primary somatosensory area, nose, layer 4"
-702,"Primary somatosensory area, nose, layer 5"
-889,"Primary somatosensory area, nose, layer 6a"
-929,"Primary somatosensory area, nose, layer 6b"
-329,"Primary somatosensory area, barrel field"
-981,"Primary somatosensory area, barrel field, layer 1"
-201,"Primary somatosensory area, barrel field, layer 2/3"
-1047,"Primary somatosensory area, barrel field, layer 4"
-1070,"Primary somatosensory area, barrel field, layer 5"
-1038,"Primary somatosensory area, barrel field, layer 6a"
-1062,"Primary somatosensory area, barrel field, layer 6b"
-337,"Primary somatosensory area, lower limb"
-1030,"Primary somatosensory area, lower limb, layer 1"
-113,"Primary somatosensory area, lower limb, layer 2/3"
-1094,"Primary somatosensory area, lower limb, layer 4"
-1128,"Primary somatosensory area, lower limb, layer 5"
-478,"Primary somatosensory area, lower limb, layer 6a"
-510,"Primary somatosensory area, lower limb, layer 6b"
-345,"Primary somatosensory area, mouth"
-878,"Primary somatosensory area, mouth, layer 1"
-657,"Primary somatosensory area, mouth, layer 2/3"
-950,"Primary somatosensory area, mouth, layer 4"
-974,"Primary somatosensory area, mouth, layer 5"
-1102,"Primary somatosensory area, mouth, layer 6a"
-2,"Primary somatosensory area, mouth, layer 6b"
-369,"Primary somatosensory area, upper limb"
-450,"Primary somatosensory area, upper limb, layer 1"
-854,"Primary somatosensory area, upper limb, layer 2/3"
-577,"Primary somatosensory area, upper limb, layer 4"
-625,"Primary somatosensory area, upper limb, layer 5"
-945,"Primary somatosensory area, upper limb, layer 6a"
-1026,"Primary somatosensory area, upper limb, layer 6b"
-361,"Primary somatosensory area, trunk"
-1006,"Primary somatosensory area, trunk, layer 1"
-670,"Primary somatosensory area, trunk, layer 2/3"
-1086,"Primary somatosensory area, trunk, layer 4"
-1111,"Primary somatosensory area, trunk, layer 5"
-9,"Primary somatosensory area, trunk, layer 6a"
-461,"Primary somatosensory area, trunk, layer 6b"
-182305689,"Primary somatosensory area, unassigned"
-182305693,"Primary somatosensory area, unassigned, layer 1"
-182305697,"Primary somatosensory area, unassigned, layer 2/3"
-182305701,"Primary somatosensory area, unassigned, layer 4"
-182305705,"Primary somatosensory area, unassigned, layer 5"
-182305709,"Primary somatosensory area, unassigned, layer 6a"
-182305713,"Primary somatosensory area, unassigned, layer 6b"
-378,Supplemental somatosensory area
-873,"Supplemental somatosensory area, layer 1"
-806,"Supplemental somatosensory area, layer 2/3"
-1035,"Supplemental somatosensory area, layer 4"
-1090,"Supplemental somatosensory area, layer 5"
-862,"Supplemental somatosensory area, layer 6a"
-893,"Supplemental somatosensory area, layer 6b"
-1057,Gustatory areas
-36,"Gustatory areas, layer 1"
-180,"Gustatory areas, layer 2/3"
-148,"Gustatory areas, layer 4"
-187,"Gustatory areas, layer 5"
-638,"Gustatory areas, layer 6a"
-662,"Gustatory areas, layer 6b"
-677,Visceral area
-897,"Visceral area, layer 1"
-1106,"Visceral area, layer 2/3"
-1010,"Visceral area, layer 4"
-1058,"Visceral area, layer 5"
-857,"Visceral area, layer 6a"
-849,"Visceral area, layer 6b"
-247,Auditory areas
-1011,Dorsal auditory area
-527,"Dorsal auditory area, layer 1"
-600,"Dorsal auditory area, layer 2/3"
-678,"Dorsal auditory area, layer 4"
-252,"Dorsal auditory area, layer 5"
-156,"Dorsal auditory area, layer 6a"
-243,"Dorsal auditory area, layer 6b"
-1002,Primary auditory area
-735,"Primary auditory area, layer 1"
-251,"Primary auditory area, layer 2/3"
-816,"Primary auditory area, layer 4"
-847,"Primary auditory area, layer 5"
-954,"Primary auditory area, layer 6a"
-1005,"Primary auditory area, layer 6b"
-1027,Posterior auditory area
-696,"Posterior auditory area, layer 1"
-643,"Posterior auditory area, layer 2/3"
-759,"Posterior auditory area, layer 4"
-791,"Posterior auditory area, layer 5"
-249,"Posterior auditory area, layer 6a"
-456,"Posterior auditory area, layer 6b"
-1018,Ventral auditory area
-959,"Ventral auditory area, layer 1"
-755,"Ventral auditory area, layer 2/3"
-990,"Ventral auditory area, layer 4"
-1023,"Ventral auditory area, layer 5"
-520,"Ventral auditory area, layer 6a"
-598,"Ventral auditory area, layer 6b"
-669,Visual areas
-801,"Visual areas, layer 1"
-561,"Visual areas, layer 2/3"
-913,"Visual areas, layer 4"
-937,"Visual areas, layer 5"
-457,"Visual areas, layer 6a"
-497,"Visual areas, layer 6b"
-402,Anterolateral visual area
-1074,"Anterolateral visual area, layer 1"
-905,"Anterolateral visual area, layer 2/3"
-1114,"Anterolateral visual area, layer 4"
-233,"Anterolateral visual area, layer 5"
-601,"Anterolateral visual area, layer 6a"
-649,"Anterolateral visual area, layer 6b"
-394,Anteromedial visual area
-281,"Anteromedial visual area, layer 1"
-1066,"Anteromedial visual area, layer 2/3"
-401,"Anteromedial visual area, layer 4"
-433,"Anteromedial visual area, layer 5"
-1046,"Anteromedial visual area, layer 6a"
-441,"Anteromedial visual area, layer 6b"
-409,Lateral visual area
-421,"Lateral visual area, layer 1"
-973,"Lateral visual area, layer 2/3"
-573,"Lateral visual area, layer 4"
-613,"Lateral visual area, layer 5"
-74,"Lateral visual area, layer 6a"
-121,"Lateral visual area, layer 6b"
-385,Primary visual area
-593,"Primary visual area, layer 1"
-821,"Primary visual area, layer 2/3"
-721,"Primary visual area, layer 4"
-778,"Primary visual area, layer 5"
-33,"Primary visual area, layer 6a"
-305,"Primary visual area, layer 6b"
-425,Posterolateral visual area
-750,"Posterolateral visual area, layer 1"
-269,"Posterolateral visual area, layer 2/3"
-869,"Posterolateral visual area, layer 4"
-902,"Posterolateral visual area, layer 5"
-377,"Posterolateral visual area, layer 6a"
-393,"Posterolateral visual area, layer 6b"
-533,posteromedial visual area
-805,"posteromedial visual area, layer 1"
-41,"posteromedial visual area, layer 2/3"
-501,"posteromedial visual area, layer 4"
-565,"posteromedial visual area, layer 5"
-257,"posteromedial visual area, layer 6a"
-469,"posteromedial visual area, layer 6b"
-31,Anterior cingulate area
-572,"Anterior cingulate area, layer 1"
-1053,"Anterior cingulate area, layer 2/3"
-739,"Anterior cingulate area, layer 5"
-179,"Anterior cingulate area, layer 6a"
-227,"Anterior cingulate area, layer 6b"
-39,"Anterior cingulate area, dorsal part"
-935,"Anterior cingulate area, dorsal part, layer 1"
-211,"Anterior cingulate area, dorsal part, layer 2/3"
-1015,"Anterior cingulate area, dorsal part, layer 5"
-919,"Anterior cingulate area, dorsal part, layer 6a"
-927,"Anterior cingulate area, dorsal part, layer 6b"
-48,"Anterior cingulate area, ventral part"
-588,"Anterior cingulate area, ventral part, layer 1"
-296,"Anterior cingulate area, ventral part, layer 2/3"
-772,"Anterior cingulate area, ventral part, layer 5"
-810,"Anterior cingulate area, ventral part, 6a"
-819,"Anterior cingulate area, ventral part, 6b"
-972,Prelimbic area
-171,"Prelimbic area, layer 1"
-195,"Prelimbic area, layer 2"
-304,"Prelimbic area, layer 2/3"
-363,"Prelimbic area, layer 5"
-84,"Prelimbic area, layer 6a"
-132,"Prelimbic area, layer 6b"
-44,Infralimbic area
-707,"Infralimbic area, layer 1"
-747,"Infralimbic area, layer 2"
-556,"Infralimbic area, layer 2/3"
-827,"Infralimbic area, layer 5"
-1054,"Infralimbic area, layer 6a"
-1081,"Infralimbic area, layer 6b"
-714,Orbital area
-264,"Orbital area, layer 1"
-492,"Orbital area, layer 2/3"
-352,"Orbital area, layer 5"
-476,"Orbital area, layer 6a"
-516,"Orbital area, layer 6b"
-723,"Orbital area, lateral part"
-448,"Orbital area, lateral part, layer 1"
-412,"Orbital area, lateral part, layer 2/3"
-630,"Orbital area, lateral part, layer 5"
-440,"Orbital area, lateral part, layer 6a"
-488,"Orbital area, lateral part, layer 6b"
-731,"Orbital area, medial part"
-484,"Orbital area, medial part, layer 1"
-524,"Orbital area, medial part, layer 2"
-582,"Orbital area, medial part, layer 2/3"
-620,"Orbital area, medial part, layer 5"
-910,"Orbital area, medial part, layer 6a"
-738,"Orbital area, ventral part"
-746,"Orbital area, ventrolateral part"
-969,"Orbital area, ventrolateral part, layer 1"
-288,"Orbital area, ventrolateral part, layer 2/3"
-1125,"Orbital area, ventrolateral part, layer 5"
-608,"Orbital area, ventrolateral part, layer 6a"
-680,"Orbital area, ventrolateral part, layer 6b"
-95,Agranular insular area
-104,"Agranular insular area, dorsal part"
-996,"Agranular insular area, dorsal part, layer 1"
-328,"Agranular insular area, dorsal part, layer 2/3"
-1101,"Agranular insular area, dorsal part, layer 5"
-783,"Agranular insular area, dorsal part, layer 6a"
-831,"Agranular insular area, dorsal part, layer 6b"
-111,"Agranular insular area, posterior part"
-120,"Agranular insular area, posterior part, layer 1"
-163,"Agranular insular area, posterior part, layer 2/3"
-344,"Agranular insular area, posterior part, layer 5"
-314,"Agranular insular area, posterior part, layer 6a"
-355,"Agranular insular area, posterior part, layer 6b"
-119,"Agranular insular area, ventral part"
-704,"Agranular insular area, ventral part, layer 1"
-694,"Agranular insular area, ventral part, layer 2/3"
-800,"Agranular insular area, ventral part, layer 5"
-675,"Agranular insular area, ventral part, layer 6a"
-699,"Agranular insular area, ventral part, layer 6b"
-254,Retrosplenial area
-894,"Retrosplenial area, lateral agranular part"
-671,"Retrosplenial area, lateral agranular part, layer 1"
-965,"Retrosplenial area, lateral agranular part, layer 2/3"
-774,"Retrosplenial area, lateral agranular part, layer 5"
-906,"Retrosplenial area, lateral agranular part, layer 6a"
-279,"Retrosplenial area, lateral agranular part, layer 6b"
-879,"Retrosplenial area, dorsal part"
-442,"Retrosplenial area, dorsal part, layer 1"
-434,"Retrosplenial area, dorsal part, layer 2/3"
-545,"Retrosplenial area, dorsal part, layer 4"
-610,"Retrosplenial area, dorsal part, layer 5"
-274,"Retrosplenial area, dorsal part, layer 6a"
-330,"Retrosplenial area, dorsal part, layer 6b"
-886,"Retrosplenial area, ventral part"
-542,"Retrosplenial area, ventral part, layer 1"
-606,"Retrosplenial area, ventral part, layer 2"
-430,"Retrosplenial area, ventral part, layer 2/3"
-687,"Retrosplenial area, ventral part, layer 5"
-590,"Retrosplenial area, ventral part, layer 6a"
-622,"Retrosplenial area, ventral part, layer 6b"
-22,Posterior parietal association areas
-532,"Posterior parietal association areas, layer 1"
-241,"Posterior parietal association areas, layer 2/3"
-635,"Posterior parietal association areas, layer 4"
-683,"Posterior parietal association areas, layer 5"
-308,"Posterior parietal association areas, layer 6a"
-340,"Posterior parietal association areas, layer 6b"
-541,Temporal association areas
-97,"Temporal association areas, layer 1"
-1127,"Temporal association areas, layer 2/3"
-234,"Temporal association areas, layer 4"
-289,"Temporal association areas, layer 5"
-729,"Temporal association areas, layer 6a"
-786,"Temporal association areas, layer 6b"
-922,Perirhinal area
-335,"Perirhinal area, layer 6a"
-368,"Perirhinal area, layer 6b"
-540,"Perirhinal area, layer 1"
-692,"Perirhinal area, layer 5"
-888,"Perirhinal area, layer 2/3"
-895,Ectorhinal area
-836,Ectorhinal area/Layer 1
-427,Ectorhinal area/Layer 2/3
-988,Ectorhinal area/Layer 5
-977,Ectorhinal area/Layer 6a
-1045,Ectorhinal area/Layer 6b
-698,Olfactory areas
-507,Main olfactory bulb
-212,"Main olfactory bulb, glomerular layer"
-220,"Main olfactory bulb, granule layer"
-228,"Main olfactory bulb, inner plexiform layer"
-236,"Main olfactory bulb, mitral layer"
-244,"Main olfactory bulb, outer plexiform layer"
-151,Accessory olfactory bulb
-188,"Accessory olfactory bulb, glomerular layer"
-196,"Accessory olfactory bulb, granular layer"
-204,"Accessory olfactory bulb, mitral layer"
-159,Anterior olfactory nucleus
-167,"Anterior olfactory nucleus, dorsal part"
-175,"Anterior olfactory nucleus, external part"
-183,"Anterior olfactory nucleus, lateral part"
-191,"Anterior olfactory nucleus, medial part"
-199,"Anterior olfactory nucleus, posteroventral part"
-160,"Anterior olfactory nucleus, layer 1"
-168,"Anterior olfactory nucleus, layer 2"
-589,Taenia tecta
-597,"Taenia tecta, dorsal part"
-297,"Taenia tecta, dorsal part, layers 1-4"
-1034,"Taenia tecta, dorsal part, layer 1"
-1042,"Taenia tecta, dorsal part, layer 2"
-1050,"Taenia tecta, dorsal part, layer 3"
-1059,"Taenia tecta, dorsal part, layer 4"
-605,"Taenia tecta, ventral part"
-306,"Taenia tecta, ventral part, layers 1-3"
-1067,"Taenia tecta, ventral part, layer 1"
-1075,"Taenia tecta, ventral part, layer 2"
-1082,"Taenia tecta, ventral part, layer 3"
-814,Dorsal peduncular area
-496,"Dorsal peduncular area, layer 1"
-535,"Dorsal peduncular area, layer 2"
-360,"Dorsal peduncular area, layer 2/3"
-646,"Dorsal peduncular area, layer 5"
-267,"Dorsal peduncular area, layer 6a"
-961,Piriform area
-152,"Piriform area, layers 1-3"
-276,"Piriform area, molecular layer"
-284,"Piriform area, pyramidal layer"
-291,"Piriform area, polymorph layer"
-619,Nucleus of the lateral olfactory tract
-392,"Nucleus of the lateral olfactory tract, layers 1-3"
-260,"Nucleus of the lateral olfactory tract, molecular layer"
-268,"Nucleus of the lateral olfactory tract, pyramidal layer"
-1139,"Nucleus of the lateral olfactory tract, layer 3"
-631,Cortical amygdalar area
-639,"Cortical amygdalar area, anterior part"
-192,"Cortical amygdalar area, anterior part, layer 1"
-200,"Cortical amygdalar area, anterior part, layer 2"
-208,"Cortical amygdalar area, anterior part, layer 3"
-647,"Cortical amygdalar area, posterior part"
-655,"Cortical amygdalar area, posterior part, lateral zone"
-584,"Cortical amygdalar area, posterior part, lateral zone, layers 1-2"
-376,"Cortical amygdalar area, posterior part, lateral zone, layers 1-3"
-216,"Cortical amygdalar area, posterior part, lateral zone, layer 1"
-224,"Cortical amygdalar area, posterior part, lateral zone, layer 2"
-232,"Cortical amygdalar area, posterior part, lateral zone, layer 3"
-663,"Cortical amygdalar area, posterior part, medial zone"
-592,"Cortical amygdalar area, posterior part, medial zone, layers 1-2"
-383,"Cortical amygdalar area, posterior part, medial zone, layers 1-3"
-240,"Cortical amygdalar area, posterior part, medial zone, layer 1"
-248,"Cortical amygdalar area, posterior part, medial zone, layer 2"
-256,"Cortical amygdalar area, posterior part, medial zone, layer 3"
-788,Piriform-amygdalar area
-400,"Piriform-amygdalar area, layers 1-3"
-408,"Piriform-amygdalar area, molecular layer"
-416,"Piriform-amygdalar area, pyramidal layer"
-424,"Piriform-amygdalar area, polymorph layer"
-566,Postpiriform transition area
-517,"Postpiriform transition area, layers 1-3"
-1140,"Postpiriform transition area, layers 1"
-1141,"Postpiriform transition area, layers 2"
-1142,"Postpiriform transition area, layers 3"
-1089,Hippocampal formation
-1080,Hippocampal region
-375,Ammon's horn
-382,Field CA1
-391,"Field CA1, stratum lacunosum-moleculare"
-399,"Field CA1, stratum oriens"
-407,"Field CA1, pyramidal layer"
-415,"Field CA1, stratum radiatum"
-423,Field CA2
-431,"Field CA2, stratum lacunosum-moleculare"
-438,"Field CA2, stratum oriens"
-446,"Field CA2, pyramidal layer"
-454,"Field CA2, stratum radiatum"
-463,Field CA3
-471,"Field CA3, stratum lacunosum-moleculare"
-479,"Field CA3, stratum lucidum"
-486,"Field CA3, stratum oriens"
-495,"Field CA3, pyramidal layer"
-504,"Field CA3, stratum radiatum"
-726,Dentate gyrus
-10703,"Dentate gyrus, molecular layer"
-10704,"Dentate gyrus, polymorph layer"
-632,"Dentate gyrus, granule cell layer"
-10702,"Dentate gyrus, subgranular zone"
-734,Dentate gyrus crest
-742,"Dentate gyrus crest, molecular layer"
-751,"Dentate gyrus crest, polymorph layer"
-758,"Dentate gyrus crest, granule cell layer"
-766,Dentate gyrus lateral blade
-775,"Dentate gyrus lateral blade, molecular layer"
-782,"Dentate gyrus lateral blade, polymorph layer"
-790,"Dentate gyrus lateral blade, granule cell layer"
-799,Dentate gyrus medial blade
-807,"Dentate gyrus medial blade, molecular layer"
-815,"Dentate gyrus medial blade, polymorph layer"
-823,"Dentate gyrus medial blade, granule cell layer"
-982,Fasciola cinerea
-19,Induseum griseum
-822,Retrohippocampal region
-909,Entorhinal area
-918,"Entorhinal area, lateral part"
-1121,"Entorhinal area, lateral part, layer 1"
-20,"Entorhinal area, lateral part, layer 2"
-999,"Entorhinal area, lateral part, layer 2/3"
-715,"Entorhinal area, lateral part, layer 2a"
-764,"Entorhinal area, lateral part, layer 2b"
-52,"Entorhinal area, lateral part, layer 3"
-92,"Entorhinal area, lateral part, layer 4"
-312,"Entorhinal area, lateral part, layer 4/5"
-139,"Entorhinal area, lateral part, layer 5"
-387,"Entorhinal area, lateral part, layer 5/6"
-28,"Entorhinal area, lateral part, layer 6a"
-60,"Entorhinal area, lateral part, layer 6b"
-926,"Entorhinal area, medial part, dorsal zone"
-526,"Entorhinal area, medial part, dorsal zone, layer 1"
-543,"Entorhinal area, medial part, dorsal zone, layer 2"
-468,"Entorhinal area, medial part, dorsal zone, layer 2a"
-508,"Entorhinal area, medial part, dorsal zone, layer 2b"
-664,"Entorhinal area, medial part, dorsal zone, layer 3"
-712,"Entorhinal area, medial part, dorsal zone, layer 4"
-727,"Entorhinal area, medial part, dorsal zone, layer 5"
-550,"Entorhinal area, medial part, dorsal zone, layer 5/6"
-743,"Entorhinal area, medial part, dorsal zone, layer 6"
-934,"Entorhinal area, medial part, ventral zone"
-259,"Entorhinal area, medial part, ventral zone, layer 1"
-324,"Entorhinal area, medial part, ventral zone, layer 2"
-371,"Entorhinal area, medial part, ventral zone, layer 3"
-419,"Entorhinal area, medial part, ventral zone, layer 4"
-1133,"Entorhinal area, medial part, ventral zone, layer 5/6"
-843,Parasubiculum
-10693,"Parasubiculum, layer 1"
-10694,"Parasubiculum, layer 2"
-10695,"Parasubiculum, layer 3"
-1037,Postsubiculum
-10696,"Postsubiculum, layer 1"
-10697,"Postsubiculum, layer 2"
-10698,"Postsubiculum, layer 3"
-1084,Presubiculum
-10699,"Presubiculum, layer 1"
-10700,"Presubiculum, layer 2"
-10701,"Presubiculum, layer 3"
-502,Subiculum
-509,"Subiculum, dorsal part"
-829,"Subiculum, dorsal part, molecular layer"
-845,"Subiculum, dorsal part, pyramidal layer"
-837,"Subiculum, dorsal part, stratum radiatum"
-518,"Subiculum, ventral part"
-853,"Subiculum, ventral part, molecular layer"
-870,"Subiculum, ventral part, pyramidal layer"
-861,"Subiculum, ventral part, stratum radiatum"
-703,Cortical subplate
-16,"Layer 6b, isocortex"
-583,Claustrum
-942,Endopiriform nucleus
-952,"Endopiriform nucleus, dorsal part"
-966,"Endopiriform nucleus, ventral part"
-131,Lateral amygdalar nucleus
-295,Basolateral amygdalar nucleus
-303,"Basolateral amygdalar nucleus, anterior part"
-311,"Basolateral amygdalar nucleus, posterior part"
-451,"Basolateral amygdalar nucleus, ventral part"
-319,Basomedial amygdalar nucleus
-327,"Basomedial amygdalar nucleus, anterior part"
-334,"Basomedial amygdalar nucleus, posterior part"
-780,Posterior amygdalar nucleus
-623,Cerebral nuclei
-477,Striatum
-485,Striatum dorsal region
-672,Caudoputamen
-493,Striatum ventral region
-56,Nucleus accumbens
-998,Fundus of striatum
-754,Olfactory tubercle
-481,Islands of Calleja
-489,Major island of Calleja
-144,"Olfactory tubercle, layers 1-3"
-458,"Olfactory tubercle, molecular layer"
-465,"Olfactory tubercle, pyramidal layer"
-473,"Olfactory tubercle, polymorph layer"
-275,Lateral septal complex
-242,Lateral septal nucleus
-250,"Lateral septal nucleus, caudal (caudodorsal) part"
-258,"Lateral septal nucleus, rostral (rostroventral) part"
-266,"Lateral septal nucleus, ventral part"
-310,Septofimbrial nucleus
-333,Septohippocampal nucleus
-278,Striatum-like amygdalar nuclei
-23,Anterior amygdalar area
-292,Bed nucleus of the accessory olfactory tract
-536,Central amygdalar nucleus
-544,"Central amygdalar nucleus, capsular part"
-551,"Central amygdalar nucleus, lateral part"
-559,"Central amygdalar nucleus, medial part"
-1105,Intercalated amygdalar nucleus
-403,Medial amygdalar nucleus
-411,"Medial amygdalar nucleus, anterodorsal part"
-418,"Medial amygdalar nucleus, anteroventral part"
-426,"Medial amygdalar nucleus, posterodorsal part"
-472,"Medial amygdalar nucleus, posterodorsal part, sublayer a"
-480,"Medial amygdalar nucleus, posterodorsal part, sublayer b"
-487,"Medial amygdalar nucleus, posterodorsal part, sublayer c"
-435,"Medial amygdalar nucleus, posteroventral part"
-803,Pallidum
-818,"Pallidum, dorsal region"
-1022,"Globus pallidus, external segment"
-1031,"Globus pallidus, internal segment"
-835,"Pallidum, ventral region"
-342,Substantia innominata
-298,Magnocellular nucleus
-826,"Pallidum, medial region"
-904,Medial septal complex
-564,Medial septal nucleus
-596,Diagonal band nucleus
-581,Triangular nucleus of septum
-809,"Pallidum, caudal region"
-351,Bed nuclei of the stria terminalis
-359,"Bed nuclei of the stria terminalis, anterior division"
-537,"Bed nuclei of the stria terminalis, anterior division, anterolateral area"
-498,"Bed nuclei of the stria terminalis, anterior division, anteromedial area"
-505,"Bed nuclei of the stria terminalis, anterior division, dorsomedial nucleus"
-513,"Bed nuclei of the stria terminalis, anterior division, fusiform nucleus"
-546,"Bed nuclei of the stria terminalis, anterior division, juxtacapsular nucleus"
-521,"Bed nuclei of the stria terminalis, anterior division, magnocellular nucleus"
-554,"Bed nuclei of the stria terminalis, anterior division, oval nucleus"
-562,"Bed nuclei of the stria terminalis, anterior division, rhomboid nucleus"
-529,"Bed nuclei of the stria terminalis, anterior division, ventral nucleus"
-367,"Bed nuclei of the stria terminalis, posterior division"
-569,"Bed nuclei of the stria terminalis, posterior division, dorsal nucleus"
-578,"Bed nuclei of the stria terminalis, posterior division, principal nucleus"
-585,"Bed nuclei of the stria terminalis, posterior division, interfascicular nucleus"
-594,"Bed nuclei of the stria terminalis, posterior division, transverse nucleus"
-602,"Bed nuclei of the stria terminalis, posterior division, strial extension"
-287,Bed nucleus of the anterior commissure
-343,Brain stem
-1129,Interbrain
-549,Thalamus
-864,"Thalamus, sensory-motor cortex related"
-637,Ventral group of the dorsal thalamus
-629,Ventral anterior-lateral complex of the thalamus
-685,Ventral medial nucleus of the thalamus
-709,Ventral posterior complex of the thalamus
-718,Ventral posterolateral nucleus of the thalamus
-725,"Ventral posterolateral nucleus of the thalamus, parvicellular part"
-733,Ventral posteromedial nucleus of the thalamus
-741,"Ventral posteromedial nucleus of the thalamus, parvicellular part"
-406,Subparafascicular nucleus
-414,"Subparafascicular nucleus, magnocellular part"
-422,"Subparafascicular nucleus, parvicellular part"
-609,Subparafascicular area
-1044,Peripeduncular nucleus
-1008,"Geniculate group, dorsal thalamus"
-475,Medial geniculate complex
-1072,"Medial geniculate complex, dorsal part"
-1079,"Medial geniculate complex, ventral part"
-1088,"Medial geniculate complex, medial part"
-170,Dorsal part of the lateral geniculate complex
-856,"Thalamus, polymodal association cortex related"
-138,Lateral group of the dorsal thalamus
-218,Lateral posterior nucleus of the thalamus
-1020,Posterior complex of the thalamus
-1029,Posterior limiting nucleus of the thalamus
-325,Suprageniculate nucleus
-239,Anterior group of the dorsal thalamus
-255,Anteroventral nucleus of thalamus
-127,Anteromedial nucleus
-1096,"Anteromedial nucleus, dorsal part"
-1104,"Anteromedial nucleus, ventral part"
-64,Anterodorsal nucleus
-1120,Interanteromedial nucleus of the thalamus
-1113,Interanterodorsal nucleus of the thalamus
-155,Lateral dorsal nucleus of thalamus
-444,Medial group of the dorsal thalamus
-59,Intermediodorsal nucleus of the thalamus
-362,Mediodorsal nucleus of thalamus
-617,"Mediodorsal nucleus of the thalamus, central part"
-626,"Mediodorsal nucleus of the thalamus, lateral part"
-636,"Mediodorsal nucleus of the thalamus, medial part"
-366,Submedial nucleus of the thalamus
-1077,Perireunensis nucleus
-571,Midline group of the dorsal thalamus
-149,Paraventricular nucleus of the thalamus
-15,Parataenial nucleus
-181,Nucleus of reunions
-51,Intralaminar nuclei of the dorsal thalamus
-189,Rhomboid nucleus
-599,Central medial nucleus of the thalamus
-907,Paracentral nucleus
-575,Central lateral nucleus of the thalamus
-930,Parafascicular nucleus
-262,Reticular nucleus of the thalamus
-1014,"Geniculate group, ventral thalamus"
-27,Intergeniculate leaflet of the lateral geniculate complex
-178,Ventral part of the lateral geniculate complex
-300,"Ventral part of the lateral geniculate complex, lateral zone"
-316,"Ventral part of the lateral geniculate complex, medial zone"
-321,Subgeniculate nucleus
-958,Epithalamus
-483,Medial habenula
-186,Lateral habenula
-953,Pineal body
-1097,Hypothalamus
-157,Periventricular zone
-390,Supraoptic nucleus
-332,Accessory supraoptic group
-432,Nucleus circularis
-38,Paraventricular hypothalamic nucleus
-71,"Paraventricular hypothalamic nucleus, magnocellular division"
-47,"Paraventricular hypothalamic nucleus, magnocellular division, anterior magnocellular part"
-79,"Paraventricular hypothalamic nucleus, magnocellular division, medial magnocellular part"
-103,"Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part"
-652,"Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part, lateral zone"
-660,"Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part, medial zone"
-94,"Paraventricular hypothalamic nucleus, parvicellular division"
-55,"Paraventricular hypothalamic nucleus, parvicellular division, anterior parvicellular part"
-87,"Paraventricular hypothalamic nucleus, parvicellular division, medial parvicellular part, dorsal zone"
-110,"Paraventricular hypothalamic nucleus, parvicellular division, periventricular part"
-30,"Periventricular hypothalamic nucleus, anterior part"
-118,"Periventricular hypothalamic nucleus, intermediate part"
-223,Arcuate hypothalamic nucleus
-141,Periventricular region
-72,Anterodorsal preoptic nucleus
-80,Anterior hypothalamic area
-263,Anteroventral preoptic nucleus
-272,Anteroventral periventricular nucleus
-830,Dorsomedial nucleus of the hypothalamus
-668,"Dorsomedial nucleus of the hypothalamus, anterior part"
-676,"Dorsomedial nucleus of the hypothalamus, posterior part"
-684,"Dorsomedial nucleus of the hypothalamus, ventral part"
-452,Median preoptic nucleus
-523,Medial preoptic area
-763,Vascular organ of the lamina terminalis
-914,Posterodorsal preoptic nucleus
-1109,Parastrial nucleus
-1124,Suprachiasmatic preoptic nucleus
-126,"Periventricular hypothalamic nucleus, posterior part"
-133,"Periventricular hypothalamic nucleus, preoptic part"
-347,Subparaventricular zone
-286,Suprachiasmatic nucleus
-338,Subfornical organ
-689,Ventrolateral preoptic nucleus
-467,Hypothalamic medial zone
-88,Anterior hypothalamic nucleus
-700,"Anterior hypothalamic nucleus, anterior part"
-708,"Anterior hypothalamic nucleus, central part"
-716,"Anterior hypothalamic nucleus, dorsal part"
-724,"Anterior hypothalamic nucleus, posterior part"
-331,Mammillary body
-210,Lateral mammillary nucleus
-491,Medial mammillary nucleus
-732,"Medial mammillary nucleus, median part"
-525,Supramammillary nucleus
-1110,"Supramammillary nucleus, lateral part"
-1118,"Supramammillary nucleus, medial part"
-557,Tuberomammillary nucleus
-1126,"Tuberomammillary nucleus, dorsal part"
-1,"Tuberomammillary nucleus, ventral part"
-515,Medial preoptic nucleus
-740,"Medial preoptic nucleus, central part"
-748,"Medial preoptic nucleus, lateral part"
-756,"Medial preoptic nucleus, medial part"
-980,Dorsal premammillary nucleus
-1004,Ventral premammillary nucleus
-63,"Paraventricular hypothalamic nucleus, descending division"
-439,"Paraventricular hypothalamic nucleus, descending division, dorsal parvicellular part"
-447,"Paraventricular hypothalamic nucleus, descending division, forniceal part"
-455,"Paraventricular hypothalamic nucleus, descending division, lateral parvicellular part"
-464,"Paraventricular hypothalamic nucleus, descending division, medial parvicellular part, ventral zone"
-693,Ventromedial hypothalamic nucleus
-761,"Ventromedial hypothalamic nucleus, anterior part"
-769,"Ventromedial hypothalamic nucleus, central part"
-777,"Ventromedial hypothalamic nucleus, dorsomedial part"
-785,"Ventromedial hypothalamic nucleus, ventrolateral part"
-946,Posterior hypothalamic nucleus
-290,Hypothalamic lateral zone
-194,Lateral hypothalamic area
-226,Lateral preoptic area
-356,Preparasubthalamic nucleus
-364,Parasubthalamic nucleus
-173,Retrochiasmatic area
-470,Subthalamic nucleus
-614,Tuberal nucleus
-797,Zona incerta
-796,Dopaminergic A13 group
-804,Fields of Forel
-10671,Median eminence
-313,Midbrain
-339,"Midbrain, sensory related"
-302,"Superior colliculus, sensory related"
-851,"Superior colliculus, optic layer"
-842,"Superior colliculus, superficial gray layer"
-834,"Superior colliculus, zonal layer"
-4,Inferior colliculus
-811,"Inferior colliculus, central nucleus"
-820,"Inferior colliculus, dorsal nucleus"
-828,"Inferior colliculus, external nucleus"
-580,Nucleus of the brachium of the inferior colliculus
-271,Nucleus sagulum
-874,Parabigeminal nucleus
-460,Midbrain trigeminal nucleus
-323,"Midbrain, motor related"
-381,"Substantia nigra, reticular part"
-749,Ventral tegmental area
-246,"Midbrain reticular nucleus, retrorubral area"
-128,Midbrain reticular nucleus
-539,"Midbrain reticular nucleus, magnocellular part"
-548,"Midbrain reticular nucleus, magnocellular part, general"
-555,"Midbrain reticular nucleus, parvicellular part"
-294,"Superior colliculus, motor related"
-26,"Superior colliculus, motor related, deep gray layer"
-42,"Superior colliculus, motor related, deep white layer"
-17,"Superior colliculus, motor related, intermediate white layer"
-10,"Superior colliculus, motor related, intermediate gray layer"
-494,"Superior colliculus, motor related, intermediate gray layer, sublayer a"
-503,"Superior colliculus, motor related, intermediate gray layer, sublayer b"
-511,"Superior colliculus, motor related, intermediate gray layer, sublayer c"
-795,Periaqueductal gray
-50,Precommissural nucleus
-67,Interstitial nucleus of Cajal
-587,Nucleus of Darkschewitsch
-1100,Pretectal region
-215,Anterior pretectal nucleus
-531,Medial pretectal area
-628,Nucleus of the optic tract
-634,Nucleus of the posterior commissure
-706,Olivary pretectal nucleus
-1061,Posterior pretectal nucleus
-616,Cuneiform nucleus
-214,Red nucleus
-35,Oculomotor nucleus
-975,Edinger-Westphal nucleus
-115,Trochlear nucleus
-757,Ventral tegmental nucleus
-231,Anterior tegmental nucleus
-66,Lateral terminal nucleus of the accessory optic tract
-75,Dorsal terminal nucleus of the accessory optic tract
-58,Medial terminal nucleus of the accessory optic tract
-615,"Substantia nigra, lateral part"
-348,"Midbrain, behavioral state related"
-374,"Substantia nigra, compact part"
-1052,Pedunculopontine nucleus
-165,Midbrain raphe nuclei
-12,Interfascicular nucleus raphe
-100,Interpeduncular nucleus
-197,Rostral linear nucleus raphe
-591,Central linear nucleus raphe
-872,Dorsal nucleus raphe
-1065,Hindbrain
-771,Pons
-1132,"Pons, sensory related"
-612,Nucleus of the lateral lemniscus
-82,"Nucleus of the lateral lemniscus, dorsal part"
-90,"Nucleus of the lateral lemniscus, horizontal part"
-99,"Nucleus of the lateral lemniscus, ventral part"
-7,Principal sensory nucleus of the trigeminal
-867,Parabrachial nucleus
-123,Koelliker-Fuse subnucleus
-881,"Parabrachial nucleus, lateral division"
-860,"Parabrachial nucleus, lateral division, central lateral part"
-868,"Parabrachial nucleus, lateral division, dorsal lateral part"
-875,"Parabrachial nucleus, lateral division, external lateral part"
-883,"Parabrachial nucleus, lateral division, superior lateral part"
-891,"Parabrachial nucleus, lateral division, ventral lateral part"
-890,"Parabrachial nucleus, medial division"
-899,"Parabrachial nucleus, medial division, external medial part"
-915,"Parabrachial nucleus, medial division, medial medial part"
-923,"Parabrachial nucleus, medial division, ventral medial part"
-398,Superior olivary complex
-122,"Superior olivary complex, periolivary region"
-105,"Superior olivary complex, medial part"
-114,"Superior olivary complex, lateral part"
-987,"Pons, motor related"
-280,Barrington's nucleus
-880,Dorsal tegmental nucleus
-283,Lateral tegmental nucleus
-898,Pontine central gray
-931,Pontine gray
-1093,"Pontine reticular nucleus, caudal part"
-552,"Pontine reticular nucleus, ventral part"
-318,Supragenual nucleus
-462,Superior salivatory nucleus
-534,Supratrigeminal nucleus
-574,Tegmental reticular nucleus
-621,Motor nucleus of trigeminal
-1117,"Pons, behavioral state related"
-679,Superior central nucleus raphe
-137,"Superior central nucleus raphe, lateral part"
-130,"Superior central nucleus raphe, medial part"
-147,Locus ceruleus
-162,Laterodorsal tegmental nucleus
-604,Nucleus incertus
-146,Pontine reticular nucleus
-238,Nucleus raphe pontis
-350,Subceruleus nucleus
-358,Sublaterodorsal nucleus
-354,Medulla
-386,"Medulla, sensory related"
-207,Area postrema
-607,Cochlear nuclei
-112,Granular lamina of the cochlear nuclei
-560,"Cochlear nucleus, subpedunclular granular region"
-96,Dorsal cochlear nucleus
-101,Ventral cochlear nucleus
-720,Dorsal column nuclei
-711,Cuneate nucleus
-1039,Gracile nucleus
-903,External cuneate nucleus
-642,Nucleus of the trapezoid body
-651,Nucleus of the solitary tract
-659,"Nucleus of the solitary tract, central part"
-666,"Nucleus of the solitary tract, commissural part"
-674,"Nucleus of the solitary tract, gelatinous part"
-682,"Nucleus of the solitary tract, lateral part"
-691,"Nucleus of the solitary tract, medial part"
-429,"Spinal nucleus of the trigeminal, caudal part"
-437,"Spinal nucleus of the trigeminal, interpolar part"
-445,"Spinal nucleus of the trigeminal, oral part"
-77,"Spinal nucleus of the trigeminal, oral part, caudal dorsomedial part"
-53,"Spinal nucleus of the trigeminal, oral part, middle dorsomedial part, dorsal zone"
-61,"Spinal nucleus of the trigeminal, oral part, middle dorsomedial part, ventral zone"
-45,"Spinal nucleus of the trigeminal, oral part, rostral dorsomedial part"
-69,"Spinal nucleus of the trigeminal, oral part, ventrolateral part"
-789,Nucleus z
-370,"Medulla, motor related"
-653,Abducens nucleus
-568,Accessory abducens nucleus
-661,Facial motor nucleus
-576,Accessory facial motor nucleus
-640,Efferent vestibular nucleus
-135,Nucleus ambiguus
-939,"Nucleus ambiguus, dorsal division"
-143,"Nucleus ambiguus, ventral division"
-839,Dorsal motor nucleus of the vagus nerve
-887,Efferent cochlear group
-1048,Gigantocellular reticular nucleus
-372,Infracerebellar nucleus
-83,Inferior olivary complex
-136,Intermediate reticular nucleus
-106,Inferior salivatory nucleus
-203,Linear nucleus of the medulla
-235,Lateral reticular nucleus
-955,"Lateral reticular nucleus, magnocellular part"
-963,"Lateral reticular nucleus, parvicellular part"
-307,Magnocellular reticular nucleus
-395,Medullary reticular nucleus
-1098,"Medullary reticular nucleus, dorsal part"
-1107,"Medullary reticular nucleus, ventral part"
-852,Parvicellular reticular nucleus
-859,Parasolitary nucleus
-938,Paragigantocellular reticular nucleus
-970,"Paragigantocellular reticular nucleus, dorsal part"
-978,"Paragigantocellular reticular nucleus, lateral part"
-154,Perihypoglossal nuclei
-161,Nucleus intercalatus
-177,Nucleus of Roller
-169,Nucleus prepositus
-995,Paramedian reticular nucleus
-1069,Parapyramidal nucleus
-185,"Parapyramidal nucleus, deep part"
-193,"Parapyramidal nucleus, superficial part"
-701,Vestibular nuclei
-209,Lateral vestibular nucleus
-202,Medial vestibular nucleus
-225,Spinal vestibular nucleus
-217,Superior vestibular nucleus
-765,Nucleus x
-773,Hypoglossal nucleus
-781,Nucleus y
-76,Interstitial nucleus of the vestibular nerve
-379,"Medulla, behavioral state related"
-206,Nucleus raphe magnus
-230,Nucleus raphe pallidus
-222,Nucleus raphe obscurus
-512,Cerebellum
-528,Cerebellar cortex
-645,Vermal regions
-912,Lingula (I)
-10707,"Lingula (I), molecular layer"
-10706,"Lingula (I), Purkinje layer"
-10705,"Lingula (I), granular layer"
-920,Central lobule
-976,Lobule II
-10710,"Lobule II, molecular layer"
-10709,"Lobule II, Purkinje layer"
-10708,"Lobule II, granular layer"
-984,Lobule III
-10713,"Lobule III, molecular layer"
-10712,"Lobule III, Purkinje layer"
-10711,"Lobule III, granular layer"
-928,Culmen
-992,Lobule IV
-10716,"Lobule IV, molecular layer"
-10715,"Lobule IV, Purkinje layer"
-10714,"Lobule IV, granular layer"
-1001,Lobule V
-10719,"Lobule V, molecular layer"
-10718,"Lobule V, Purkinje layer"
-10717,"Lobule V, granular layer"
-1091,Lobules IV-V
-10722,"Lobules IV-V, molecular layer"
-10721,"Lobules IV-V, Purkinje layer"
-10720,"Lobules IV-V, granular layer"
-936,Declive (VI)
-10725,"Declive (VI), molecular layer"
-10724,"Declive (VI), Purkinje layer"
-10723,"Declive (VI), granular layer"
-944,Folium-tuber vermis (VII)
-10728,"Folium-tuber vermis (VII), molecular layer"
-10727,"Folium-tuber vermis (VII), Purkinje layer"
-10726,"Folium-tuber vermis (VII), granular layer"
-951,Pyramus (VIII)
-10731,"Pyramus (VIII), molecular layer"
-10730,"Pyramus (VIII), Purkinje layer"
-10729,"Pyramus (VIII), granular layer"
-957,Uvula (IX)
-10734,"Uvula (IX), molecular layer"
-10733,"Uvula (IX), Purkinje layer"
-10732,"Uvula (IX), granular layer"
-968,Nodulus (X)
-10737,"Nodulus (X), molecular layer"
-10736,"Nodulus (X), Purkinje layer"
-10735,"Nodulus (X), granular layer"
-1073,Hemispheric regions
-1007,Simple lobule
-10674,"Simple lobule, molecular layer"
-10673,"Simple lobule, Purkinje layer"
-10672,"Simple lobule, granular layer"
-1017,Ansiform lobule
-1056,Crus 1
-10677,"Crus 1, molecular layer"
-10676,"Crus 1, Purkinje layer"
-10675,"Crus 1, granular layer"
-1064,Crus 2
-10680,"Crus 2, molecular layer"
-10679,"Crus 2, Purkinje layer"
-10678,"Crus 2, granular layer"
-1025,Paramedian lobule
-10683,"Paramedian lobule, molecular layer"
-10682,"Paramedian lobule, Purkinje layer"
-10681,"Paramedian lobule, granular layer"
-1033,Copula pyramidis
-10686,"Copula pyramidis, molecular layer"
-10685,"Copula pyramidis, Purkinje layer"
-10684,"Copula pyramidis, granular layer"
-1041,Paraflocculus
-10689,"Paraflocculus, molecular layer"
-10688,"Paraflocculus, Purkinje layer"
-10687,"Paraflocculus, granular layer"
-1049,Flocculus
-10692,"Flocculus, molecular layer"
-10691,"Flocculus, Purkinje layer"
-10690,"Flocculus, granular layer"
-1144,"Cerebellar cortex, molecular layer"
-1145,"Cerebellar cortex, Purkinje layer"
-1143,"Cerebellar cortex, granular layer"
-519,Cerebellar nuclei
-989,Fastigial nucleus
-91,Interposed nucleus
-846,Dentate nucleus
-1009,fiber tracts
-967,cranial nerves
-885,terminal nerve
-949,vomeronasal nerve
-840,olfactory nerve
-1016,olfactory nerve layer of main olfactory bulb
-21,"lateral olfactory tract, general"
-665,"lateral olfactory tract, body"
-538,dorsal limb
-459,accessory olfactory tract
-900,"anterior commissure, olfactory limb"
-848,optic nerve
-876,accessory optic tract
-916,brachium of the superior colliculus
-336,superior colliculus commissure
-117,optic chiasm
-125,optic tract
-357,tectothalamic pathway
-832,oculomotor nerve
-62,medial longitudinal fascicle
-158,posterior commissure
-911,trochlear nerve
-384,trochlear nerve decussation
-710,abducens nerve
-901,trigeminal nerve
-93,motor root of the trigeminal nerve
-229,sensory root of the trigeminal nerve
-705,midbrain tract of the trigeminal nerve
-794,spinal tract of the trigeminal nerve
-798,facial nerve
-1131,intermediate nerve
-1116,genu of the facial nerve
-933,vestibulocochlear nerve
-1076,efferent cochleovestibular bundle
-413,vestibular nerve
-948,cochlear nerve
-841,trapezoid body
-641,intermediate acoustic stria
-506,dorsal acoustic stria
-658,lateral lemniscus
-633,inferior colliculus commissure
-482,brachium of the inferior colliculus
-808,glossopharyngeal nerve
-917,vagus nerve
-237,solitary tract
-717,accessory spinal nerve
-813,hypoglossal nerve
-925,ventral roots
-792,dorsal roots
-932,cervicothalamic tract
-570,dorsolateral fascicle
-522,dorsal commissure of the spinal cord
-858,ventral commissure of the spinal cord
-586,fasciculus proprius
-514,dorsal column
-380,cuneate fascicle
-388,gracile fascicle
-396,internal arcuate fibers
-697,medial lemniscus
-871,spinothalamic tract
-29,lateral spinothalamic tract
-389,ventral spinothalamic tract
-245,spinocervical tract
-261,spino-olivary pathway
-270,spinoreticular pathway
-293,spinovestibular pathway
-277,spinotectal pathway
-253,spinohypothalamic pathway
-285,spinotelenchephalic pathway
-627,hypothalamohypophysial tract
-960,cerebellum related fiber tracts
-744,cerebellar commissure
-752,cerebellar peduncles
-326,superior cerebelar peduncles
-812,superior cerebellar peduncle decussation
-85,spinocerebellar tract
-850,uncinate fascicle
-866,ventral spinocerebellar tract
-78,middle cerebellar peduncle
-1123,inferior cerebellar peduncle
-553,dorsal spinocerebellar tract
-499,cuneocerebellar tract
-650,juxtarestiform body
-490,bulbocerebellar tract
-404,olivocerebellar tract
-410,reticulocerebellar tract
-373,trigeminocerebellar tract
-728,arbor vitae
-983,lateral forebrain bundle system
-776,corpus callosum
-956,"corpus callosum, anterior forceps"
-579,external capsule
-964,"corpus callosum, extreme capsule"
-1108,genu of corpus callosum
-971,"corpus callosum, posterior forceps"
-979,"corpus callosum, rostrum"
-986,"corpus callosum, splenium"
-784,corticospinal tract
-6,internal capsule
-924,cerebal peduncle
-1036,corticotectal tract
-1012,corticorubral tract
-1003,corticopontine tract
-994,corticobulbar tract
-190,pyramid
-198,pyramidal decussation
-1019,"corticospinal tract, crossed"
-1028,"corticospinal tract, uncrossed"
-896,thalamus related
-1092,external medullary lamina of the thalamus
-14,internal medullary lamina of the thalamus
-86,middle thalamic commissure
-365,thalamic peduncles
-1000,extrapyramidal fiber systems
-760,cerebral nuclei related
-142,pallidothalmic pathway
-102,nigrostriatal tract
-109,nigrothalamic fibers
-134,pallidotegmental fascicle
-309,striatonigral pathway
-317,subthalamic fascicle
-877,tectospinal pathway
-1051,direct tectospinal pathway
-1060,doral tegmental decussation
-1043,crossed tectospinal pathway
-863,rubrospinal tract
-397,ventral tegmental decussation
-221,rubroreticular tract
-736,central tegmental bundle
-855,retriculospinal tract
-205,"retriculospinal tract, lateral part"
-213,"retriculospinal tract, medial part"
-941,vestibulospinal pathway
-991,medial forebrain bundle system
-768,cerebrum related
-884,amygdalar capsule
-892,ansa peduncularis
-908,"anterior commissure, temporal limb"
-940,cingulum bundle
-1099,fornix system
-466,alveus
-530,dorsal fornix
-603,fimbria
-745,"precommissural fornix, general"
-420,precommissural fornix diagonal band
-737,postcommissural fornix
-428,medial corticohypothalmic tract
-436,columns of the fornix
-618,hippocampal commissures
-443,dorsal hippocampal commissure
-449,ventral hippocampal commissure
-713,perforant path
-474,angular path
-37,longitudinal association bundle
-301,stria terminalis
-824,hypothalamus related
-54,medial forebrain bundle
-405,ventrolateral hypothalamic tract
-174,preoptic commissure
-349,supraoptic commissures
-817,"supraoptic commissures, anterior"
-825,"supraoptic commissures, dorsal"
-833,"supraoptic commissures, ventral"
-166,premammillary commissure
-341,supramammillary decussation
-182,propriohypothalamic pathways
-762,"propriohypothalamic pathways, dorsal"
-770,"propriohypothalamic pathways, lateral"
-779,"propriohypothalamic pathways, medial"
-787,"propriohypothalamic pathways, ventral"
-150,periventricular bundle of the hypothalamus
-46,mammillary related
-753,principal mammillary tract
-690,mammilothalmic tract
-681,mammillotegmental tract
-673,mammillary peduncle
-1068,dorsal thalamus related
-722,periventricular bundle of the thalamus
-1083,epithalamus related
-802,stria medullaris
-595,fasciculus retroflexus
-611,habenular commissure
-730,pineal stalk
-70,midbrain related
-547,dorsal longitudinal fascicle
-563,dorsal tegmental tract
-73,ventricular systems
-81,lateral ventricle
-89,rhinocele
-98,subependymal zone
-108,choroid plexus
-116,choroid fissure
-124,interventricular foramen
-129,third ventricle
-140,cerebral aqueduct
-145,fourth ventricle
-153,lateral recess
-164,"central canal, spinal cord/medulla"
-1024,grooves
-1032,grooves of the cerebral cortex
-1055,endorhinal groove
-1063,hippocampal fissure
-1071,rhinal fissure
-1078,rhinal incisure
-1040,grooves of the cerebellar cortex
-1087,precentral fissure
-1095,preculminate fissure
-1103,primary fissure
-1112,posterior superior fissure
-1119,prepyramidal fissure
-3,secondary fissure
-11,posterolateral fissure
-18,nodular fissure
-25,simple fissure
-34,intercrural fissure
-43,ansoparamedian fissure
-49,intraparafloccular fissure
-57,paramedian sulcus
-65,parafloccular sulcus
-624,Interpeduncular fossa
-304325711,retina
+997,root,FFFFFF
+8,Basic cell groups and regions,BFDAE3
+567,Cerebrum,B0F0FF
+688,Cerebral cortex,B0FFB8
+695,Cortical plate,70FF70
+315,Isocortex,70FF71
+184,Frontal pole, cerebral cortex,268F45
+68,Frontal pole, layer 1,268F45
+667,Frontal pole, layer 2/3,268F45
+500,Somatomotor areas,1F9D5A
+107,Somatomotor areas, Layer 1,1F9D5A
+219,Somatomotor areas, Layer 2/3,1F9D5A
+299,Somatomotor areas, Layer 5,1F9D5A
+644,Somatomotor areas, Layer 6a,1F9D5A
+947,Somatomotor areas, Layer 6b,1F9D5A
+985,Primary motor area,1F9D5A
+320,Primary motor area, Layer 1,1F9D5A
+943,Primary motor area, Layer 2/3,1F9D5A
+648,Primary motor area, Layer 5,1F9D5A
+844,Primary motor area, Layer 6a,1F9D5A
+882,Primary motor area, Layer 6b,1F9D5A
+993,Secondary motor area,1F9D5A
+656,Secondary motor area, layer 1,1F9D5A
+962,Secondary motor area, layer 2/3,1F9D5A
+767,Secondary motor area, layer 5,1F9D5A
+1021,Secondary motor area, layer 6a,1F9D5A
+1085,Secondary motor area, layer 6b,1F9D5A
+453,Somatosensory areas,188064
+12993,Somatosensory areas, layer 1,188064
+12994,Somatosensory areas, layer 2/3,188064
+12995,Somatosensory areas, layer 4,188064
+12996,Somatosensory areas, layer 5,188064
+12997,Somatosensory areas, layer 6a,188064
+12998,Somatosensory areas, layer 6b,188064
+322,Primary somatosensory area,188064
+793,Primary somatosensory area, layer 1,188064
+346,Primary somatosensory area, layer 2/3,188064
+865,Primary somatosensory area, layer 4,188064
+921,Primary somatosensory area, layer 5,188064
+686,Primary somatosensory area, layer 6a,188064
+719,Primary somatosensory area, layer 6b,188064
+353,Primary somatosensory area, nose,188064
+558,Primary somatosensory area, nose, layer 1,188064
+838,Primary somatosensory area, nose, layer 2/3,188064
+654,Primary somatosensory area, nose, layer 4,188064
+702,Primary somatosensory area, nose, layer 5,188064
+889,Primary somatosensory area, nose, layer 6a,188064
+929,Primary somatosensory area, nose, layer 6b,188064
+329,Primary somatosensory area, barrel field,188064
+981,Primary somatosensory area, barrel field, layer 1,188064
+201,Primary somatosensory area, barrel field, layer 2/3,188064
+1047,Primary somatosensory area, barrel field, layer 4,188064
+1070,Primary somatosensory area, barrel field, layer 5,188064
+1038,Primary somatosensory area, barrel field, layer 6a,188064
+1062,Primary somatosensory area, barrel field, layer 6b,188064
+337,Primary somatosensory area, lower limb,188064
+1030,Primary somatosensory area, lower limb, layer 1,188064
+113,Primary somatosensory area, lower limb, layer 2/3,188064
+1094,Primary somatosensory area, lower limb, layer 4,188064
+1128,Primary somatosensory area, lower limb, layer 5,188064
+478,Primary somatosensory area, lower limb, layer 6a,188064
+510,Primary somatosensory area, lower limb, layer 6b,188064
+345,Primary somatosensory area, mouth,188064
+878,Primary somatosensory area, mouth, layer 1,188064
+657,Primary somatosensory area, mouth, layer 2/3,188064
+950,Primary somatosensory area, mouth, layer 4,188064
+974,Primary somatosensory area, mouth, layer 5,188064
+1102,Primary somatosensory area, mouth, layer 6a,188064
+2,Primary somatosensory area, mouth, layer 6b,188064
+369,Primary somatosensory area, upper limb,188064
+450,Primary somatosensory area, upper limb, layer 1,188064
+854,Primary somatosensory area, upper limb, layer 2/3,188064
+577,Primary somatosensory area, upper limb, layer 4,188064
+625,Primary somatosensory area, upper limb, layer 5,188064
+945,Primary somatosensory area, upper limb, layer 6a,188064
+1026,Primary somatosensory area, upper limb, layer 6b,188064
+361,Primary somatosensory area, trunk,188064
+1006,Primary somatosensory area, trunk, layer 1,188064
+670,Primary somatosensory area, trunk, layer 2/3,188064
+1086,Primary somatosensory area, trunk, layer 4,188064
+1111,Primary somatosensory area, trunk, layer 5,188064
+9,Primary somatosensory area, trunk, layer 6a,188064
+461,Primary somatosensory area, trunk, layer 6b,188064
+182305689,Primary somatosensory area, unassigned,188064
+182305693,Primary somatosensory area, unassigned, layer 1,188064
+182305697,Primary somatosensory area, unassigned, layer 2/3,188064
+182305701,Primary somatosensory area, unassigned, layer 4,188064
+182305705,Primary somatosensory area, unassigned, layer 5,188064
+182305709,Primary somatosensory area, unassigned, layer 6a,188064
+182305713,Primary somatosensory area, unassigned, layer 6b,188064
+378,Supplemental somatosensory area,188064
+873,Supplemental somatosensory area, layer 1,188064
+806,Supplemental somatosensory area, layer 2/3,188064
+1035,Supplemental somatosensory area, layer 4,188064
+1090,Supplemental somatosensory area, layer 5,188064
+862,Supplemental somatosensory area, layer 6a,188064
+893,Supplemental somatosensory area, layer 6b,188064
+1057,Gustatory areas,009C75
+36,Gustatory areas, layer 1,009C75
+180,Gustatory areas, layer 2/3,009C75
+148,Gustatory areas, layer 4,009C75
+187,Gustatory areas, layer 5,009C75
+638,Gustatory areas, layer 6a,009C75
+662,Gustatory areas, layer 6b,009C75
+677,Visceral area,11AD83
+897,Visceral area, layer 1,11AD83
+1106,Visceral area, layer 2/3,11AD83
+1010,Visceral area, layer 4,11AD83
+1058,Visceral area, layer 5,11AD83
+857,Visceral area, layer 6a,11AD83
+849,Visceral area, layer 6b,11AD83
+247,Auditory areas,19399
+1011,Dorsal auditory area,19399
+527,Dorsal auditory area, layer 1,19399
+600,Dorsal auditory area, layer 2/3,19399
+678,Dorsal auditory area, layer 4,19399
+252,Dorsal auditory area, layer 5,19399
+156,Dorsal auditory area, layer 6a,19399
+243,Dorsal auditory area, layer 6b,19399
+1002,Primary auditory area,19399
+735,Primary auditory area, layer 1,19399
+251,Primary auditory area, layer 2/3,19399
+816,Primary auditory area, layer 4,19399
+847,Primary auditory area, layer 5,19399
+954,Primary auditory area, layer 6a,19399
+1005,Primary auditory area, layer 6b,19399
+1027,Posterior auditory area,19399
+696,Posterior auditory area, layer 1,19399
+643,Posterior auditory area, layer 2/3,19399
+759,Posterior auditory area, layer 4,19399
+791,Posterior auditory area, layer 5,19399
+249,Posterior auditory area, layer 6a,19399
+456,Posterior auditory area, layer 6b,19399
+1018,Ventral auditory area,19399
+959,Ventral auditory area, layer 1,19399
+755,Ventral auditory area, layer 2/3,19399
+990,Ventral auditory area, layer 4,19399
+1023,Ventral auditory area, layer 5,19399
+520,Ventral auditory area, layer 6a,19399
+598,Ventral auditory area, layer 6b,19399
+669,Visual areas,08858C
+801,Visual areas, layer 1,08858C
+561,Visual areas, layer 2/3,08858C
+913,Visual areas, layer 4,08858C
+937,Visual areas, layer 5,08858C
+457,Visual areas, layer 6a,08858C
+497,Visual areas, layer 6b,08858C
+402,Anterolateral visual area,08858C
+1074,Anterolateral visual area, layer 1,08858C
+905,Anterolateral visual area, layer 2/3,08858C
+1114,Anterolateral visual area, layer 4,08858C
+233,Anterolateral visual area, layer 5,08858C
+601,Anterolateral visual area, layer 6a,08858C
+649,Anterolateral visual area, layer 6b,08858C
+394,Anteromedial visual area,08858C
+281,Anteromedial visual area, layer 1,08858C
+1066,Anteromedial visual area, layer 2/3,08858C
+401,Anteromedial visual area, layer 4,08858C
+433,Anteromedial visual area, layer 5,08858C
+1046,Anteromedial visual area, layer 6a,08858C
+441,Anteromedial visual area, layer 6b,08858C
+409,Lateral visual area,08858C
+421,Lateral visual area, layer 1,08858C
+973,Lateral visual area, layer 2/3,08858C
+573,Lateral visual area, layer 4,08858C
+613,Lateral visual area, layer 5,08858C
+74,Lateral visual area, layer 6a,08858C
+121,Lateral visual area, layer 6b,08858C
+385,Primary visual area,08858C
+593,Primary visual area, layer 1,08858C
+821,Primary visual area, layer 2/3,08858C
+721,Primary visual area, layer 4,08858C
+778,Primary visual area, layer 5,08858C
+33,Primary visual area, layer 6a,08858C
+305,Primary visual area, layer 6b,08858C
+425,Posterolateral visual area,08858C
+750,Posterolateral visual area, layer 1,08858C
+269,Posterolateral visual area, layer 2/3,08858C
+869,Posterolateral visual area, layer 4,08858C
+902,Posterolateral visual area, layer 5,08858C
+377,Posterolateral visual area, layer 6a,08858C
+393,Posterolateral visual area, layer 6b,08858C
+533,posteromedial visual area,08858C
+805,posteromedial visual area, layer 1,08858C
+41,posteromedial visual area, layer 2/3,08858C
+501,posteromedial visual area, layer 4,08858C
+565,posteromedial visual area, layer 5,08858C
+257,posteromedial visual area, layer 6a,08858C
+469,posteromedial visual area, layer 6b,08858C
+31,Anterior cingulate area,40A666
+572,Anterior cingulate area, layer 1,40A666
+1053,Anterior cingulate area, layer 2/3,40A666
+739,Anterior cingulate area, layer 5,40A666
+179,Anterior cingulate area, layer 6a,40A666
+227,Anterior cingulate area, layer 6b,40A666
+39,Anterior cingulate area, dorsal part,40A666
+935,Anterior cingulate area, dorsal part, layer 1,40A666
+211,Anterior cingulate area, dorsal part, layer 2/3,40A666
+1015,Anterior cingulate area, dorsal part, layer 5,40A666
+919,Anterior cingulate area, dorsal part, layer 6a,40A666
+927,Anterior cingulate area, dorsal part, layer 6b,40A666
+48,Anterior cingulate area, ventral part,40A666
+588,Anterior cingulate area, ventral part, layer 1,40A666
+296,Anterior cingulate area, ventral part, layer 2/3,40A666
+772,Anterior cingulate area, ventral part, layer 5,40A666
+810,Anterior cingulate area, ventral part, 6a,40A666
+819,Anterior cingulate area, ventral part, 6b,40A666
+972,Prelimbic area,2FA850
+171,Prelimbic area, layer 1,2FA850
+195,Prelimbic area, layer 2,2FA850
+304,Prelimbic area, layer 2/3,2FA850
+363,Prelimbic area, layer 5,2FA850
+84,Prelimbic area, layer 6a,2FA850
+132,Prelimbic area, layer 6b,2FA850
+44,Infralimbic area,59B363
+707,Infralimbic area, layer 1,59B363
+747,Infralimbic area, layer 2,59B363
+556,Infralimbic area, layer 2/3,59B363
+827,Infralimbic area, layer 5,59B363
+1054,Infralimbic area, layer 6a,59B363
+1081,Infralimbic area, layer 6b,59B363
+714,Orbital area,248A5E
+264,Orbital area, layer 1,248A5E
+492,Orbital area, layer 2/3,248A5E
+352,Orbital area, layer 5,248A5E
+476,Orbital area, layer 6a,248A5E
+516,Orbital area, layer 6b,248A5E
+723,Orbital area, lateral part,248A5E
+448,Orbital area, lateral part, layer 1,248A5E
+412,Orbital area, lateral part, layer 2/3,248A5E
+630,Orbital area, lateral part, layer 5,248A5E
+440,Orbital area, lateral part, layer 6a,248A5E
+488,Orbital area, lateral part, layer 6b,248A5E
+731,Orbital area, medial part,248A5E
+484,Orbital area, medial part, layer 1,248A5E
+524,Orbital area, medial part, layer 2,248A5E
+582,Orbital area, medial part, layer 2/3,248A5E
+620,Orbital area, medial part, layer 5,248A5E
+910,Orbital area, medial part, layer 6a,248A5E
+738,Orbital area, ventral part,248A5E
+746,Orbital area, ventrolateral part,248A5E
+969,Orbital area, ventrolateral part, layer 1,248A5E
+288,Orbital area, ventrolateral part, layer 2/3,248A5E
+1125,Orbital area, ventrolateral part, layer 5,248A5E
+608,Orbital area, ventrolateral part, layer 6a,248A5E
+680,Orbital area, ventrolateral part, layer 6b,248A5E
+95,Agranular insular area,219866
+104,Agranular insular area, dorsal part,219866
+996,Agranular insular area, dorsal part, layer 1,219866
+328,Agranular insular area, dorsal part, layer 2/3,219866
+1101,Agranular insular area, dorsal part, layer 5,219866
+783,Agranular insular area, dorsal part, layer 6a,219866
+831,Agranular insular area, dorsal part, layer 6b,219866
+111,Agranular insular area, posterior part,219866
+120,Agranular insular area, posterior part, layer 1,219866
+163,Agranular insular area, posterior part, layer 2/3,219866
+344,Agranular insular area, posterior part, layer 5,219866
+314,Agranular insular area, posterior part, layer 6a,219866
+355,Agranular insular area, posterior part, layer 6b,219866
+119,Agranular insular area, ventral part,219866
+704,Agranular insular area, ventral part, layer 1,219866
+694,Agranular insular area, ventral part, layer 2/3,219866
+800,Agranular insular area, ventral part, layer 5,219866
+675,Agranular insular area, ventral part, layer 6a,219866
+699,Agranular insular area, ventral part, layer 6b,219866
+254,Retrosplenial area,1AA698
+894,Retrosplenial area, lateral agranular part,1AA698
+671,Retrosplenial area, lateral agranular part, layer 1,1AA698
+965,Retrosplenial area, lateral agranular part, layer 2/3,1AA698
+774,Retrosplenial area, lateral agranular part, layer 5,1AA698
+906,Retrosplenial area, lateral agranular part, layer 6a,1AA698
+279,Retrosplenial area, lateral agranular part, layer 6b,1AA698
+879,Retrosplenial area, dorsal part,1AA698
+442,Retrosplenial area, dorsal part, layer 1,1AA698
+434,Retrosplenial area, dorsal part, layer 2/3,1AA698
+545,Retrosplenial area, dorsal part, layer 4,1AA698
+610,Retrosplenial area, dorsal part, layer 5,1AA698
+274,Retrosplenial area, dorsal part, layer 6a,1AA698
+330,Retrosplenial area, dorsal part, layer 6b,1AA698
+886,Retrosplenial area, ventral part,1AA698
+542,Retrosplenial area, ventral part, layer 1,1AA698
+606,Retrosplenial area, ventral part, layer 2,1AA698
+430,Retrosplenial area, ventral part, layer 2/3,1AA698
+687,Retrosplenial area, ventral part, layer 5,1AA698
+590,Retrosplenial area, ventral part, layer 6a,1AA698
+622,Retrosplenial area, ventral part, layer 6b,1AA698
+22,Posterior parietal association areas,009FAC
+532,Posterior parietal association areas, layer 1,009FAC
+241,Posterior parietal association areas, layer 2/3,009FAC
+635,Posterior parietal association areas, layer 4,009FAC
+683,Posterior parietal association areas, layer 5,009FAC
+308,Posterior parietal association areas, layer 6a,009FAC
+340,Posterior parietal association areas, layer 6b,009FAC
+541,Temporal association areas,15B0B3
+97,Temporal association areas, layer 1,15B0B3
+1127,Temporal association areas, layer 2/3,15B0B3
+234,Temporal association areas, layer 4,15B0B3
+289,Temporal association areas, layer 5,15B0B3
+729,Temporal association areas, layer 6a,15B0B3
+786,Temporal association areas, layer 6b,15B0B3
+922,Perirhinal area,0E9684
+335,Perirhinal area, layer 6a,0E9684
+368,Perirhinal area, layer 6b,0E9684
+540,Perirhinal area, layer 1,0E9684
+692,Perirhinal area, layer 5,0E9684
+888,Perirhinal area, layer 2/3,0E9684
+895,Ectorhinal area,0D9F91
+836,Ectorhinal area/Layer 1,0D9F91
+427,Ectorhinal area/Layer 2/3,0D9F91
+988,Ectorhinal area/Layer 5,0D9F91
+977,Ectorhinal area/Layer 6a,0D9F91
+1045,Ectorhinal area/Layer 6b,0D9F91
+698,Olfactory areas,9AD2BD
+507,Main olfactory bulb,9AD2BD
+212,Main olfactory bulb, glomerular layer,82C7AE
+220,Main olfactory bulb, granule layer,82C7AE
+228,Main olfactory bulb, inner plexiform layer,9AD2BD
+236,Main olfactory bulb, mitral layer,82C7AE
+244,Main olfactory bulb, outer plexiform layer,9AD2BD
+151,Accessory olfactory bulb,9DF0D2
+188,Accessory olfactory bulb, glomerular layer,9DF0D2
+196,Accessory olfactory bulb, granular layer,95E4C8
+204,Accessory olfactory bulb, mitral layer,9DF0D2
+159,Anterior olfactory nucleus,54BF94
+167,Anterior olfactory nucleus, dorsal part,54BF94
+175,Anterior olfactory nucleus, external part,54BF94
+183,Anterior olfactory nucleus, lateral part,54BF94
+191,Anterior olfactory nucleus, medial part,54BF94
+199,Anterior olfactory nucleus, posteroventral part,54BF94
+160,Anterior olfactory nucleus, layer 1,54BF94
+168,Anterior olfactory nucleus, layer 2,54BF94
+589,Taenia tecta,62D09F
+597,Taenia tecta, dorsal part,62D09F
+297,Taenia tecta, dorsal part, layers 1-4,62D09F
+1034,Taenia tecta, dorsal part, layer 1,62D09F
+1042,Taenia tecta, dorsal part, layer 2,62D09F
+1050,Taenia tecta, dorsal part, layer 3,62D09F
+1059,Taenia tecta, dorsal part, layer 4,62D09F
+605,Taenia tecta, ventral part,62D09F
+306,Taenia tecta, ventral part, layers 1-3,62D09F
+1067,Taenia tecta, ventral part, layer 1,62D09F
+1075,Taenia tecta, ventral part, layer 2,62D09F
+1082,Taenia tecta, ventral part, layer 3,62D09F
+814,Dorsal peduncular area,A4DAA4
+496,Dorsal peduncular area, layer 1,A4DAA4
+535,Dorsal peduncular area, layer 2,A4DAA4
+360,Dorsal peduncular area, layer 2/3,A4DAA4
+646,Dorsal peduncular area, layer 5,A4DAA4
+267,Dorsal peduncular area, layer 6a,A4DAA4
+961,Piriform area,6ACBBA
+152,Piriform area, layers 1-3,6ACBBA
+276,Piriform area, molecular layer,6ACBBA
+284,Piriform area, pyramidal layer,6ACBBA
+291,Piriform area, polymorph layer,6ACBBA
+619,Nucleus of the lateral olfactory tract,95E4C8
+392,Nucleus of the lateral olfactory tract, layers 1-3,95E4C8
+260,Nucleus of the lateral olfactory tract, molecular layer,95E4C8
+268,Nucleus of the lateral olfactory tract, pyramidal layer,95E4C8
+1139,Nucleus of the lateral olfactory tract, layer 3,95E4C8
+631,Cortical amygdalar area,61E7B7
+639,Cortical amygdalar area, anterior part,61E7B7
+192,Cortical amygdalar area, anterior part, layer 1,61E7B7
+200,Cortical amygdalar area, anterior part, layer 2,61E7B7
+208,Cortical amygdalar area, anterior part, layer 3,61E7B7
+647,Cortical amygdalar area, posterior part,61E7B7
+655,Cortical amygdalar area, posterior part, lateral zone,61E7B7
+584,Cortical amygdalar area, posterior part, lateral zone, layers 1-2,61E7B7
+376,Cortical amygdalar area, posterior part, lateral zone, layers 1-3,61E7B7
+216,Cortical amygdalar area, posterior part, lateral zone, layer 1,61E7B7
+224,Cortical amygdalar area, posterior part, lateral zone, layer 2,61E7B7
+232,Cortical amygdalar area, posterior part, lateral zone, layer 3,61E7B7
+663,Cortical amygdalar area, posterior part, medial zone,61E7B7
+592,Cortical amygdalar area, posterior part, medial zone, layers 1-2,61E7B7
+383,Cortical amygdalar area, posterior part, medial zone, layers 1-3,61E7B7
+240,Cortical amygdalar area, posterior part, medial zone, layer 1,61E7B7
+248,Cortical amygdalar area, posterior part, medial zone, layer 2,61E7B7
+256,Cortical amygdalar area, posterior part, medial zone, layer 3,61E7B7
+788,Piriform-amygdalar area,59DAAB
+400,Piriform-amygdalar area, layers 1-3,59DAAB
+408,Piriform-amygdalar area, molecular layer,59DAAB
+416,Piriform-amygdalar area, pyramidal layer,59DAAB
+424,Piriform-amygdalar area, polymorph layer,59DAAB
+566,Postpiriform transition area,A8ECD3
+517,Postpiriform transition area, layers 1-3,A8ECD3
+1140,Postpiriform transition area, layers 1,A8ECD3
+1141,Postpiriform transition area, layers 2,A8ECD3
+1142,Postpiriform transition area, layers 3,A8ECD3
+1089,Hippocampal formation,7ED04B
+1080,Hippocampal region,7ED04B
+375,Ammon's horn,7ED04B
+382,Field CA1,7ED04B
+391,Field CA1, stratum lacunosum-moleculare,7ED04B
+399,Field CA1, stratum oriens,7ED04B
+407,Field CA1, pyramidal layer,66A83D
+415,Field CA1, stratum radiatum,7ED04B
+423,Field CA2,7ED04B
+431,Field CA2, stratum lacunosum-moleculare,7ED04B
+438,Field CA2, stratum oriens,7ED04B
+446,Field CA2, pyramidal layer,66A83D
+454,Field CA2, stratum radiatum,7ED04B
+463,Field CA3,7ED04B
+471,Field CA3, stratum lacunosum-moleculare,7ED04B
+479,Field CA3, stratum lucidum,7ED04B
+486,Field CA3, stratum oriens,7ED04B
+495,Field CA3, pyramidal layer,66A83D
+504,Field CA3, stratum radiatum,7ED04B
+726,Dentate gyrus,7ED04B
+10703,Dentate gyrus, molecular layer,7ED04B
+10704,Dentate gyrus, polymorph layer,7ED04B
+632,Dentate gyrus, granule cell layer,66A83D
+10702,Dentate gyrus, subgranular zone,7ED04B
+734,Dentate gyrus crest,7ED04B
+742,Dentate gyrus crest, molecular layer,7ED04B
+751,Dentate gyrus crest, polymorph layer,7ED04B
+758,Dentate gyrus crest, granule cell layer,7ED04B
+766,Dentate gyrus lateral blade,7ED04B
+775,Dentate gyrus lateral blade, molecular layer,7ED04B
+782,Dentate gyrus lateral blade, polymorph layer,7ED04B
+790,Dentate gyrus lateral blade, granule cell layer,7ED04B
+799,Dentate gyrus medial blade,7ED04B
+807,Dentate gyrus medial blade, molecular layer,7ED04B
+815,Dentate gyrus medial blade, polymorph layer,7ED04B
+823,Dentate gyrus medial blade, granule cell layer,7ED04B
+982,Fasciola cinerea,7ED04B
+19,Induseum griseum,7ED04B
+822,Retrohippocampal region,32B825
+909,Entorhinal area,32B825
+918,Entorhinal area, lateral part,32B825
+1121,Entorhinal area, lateral part, layer 1,32B825
+20,Entorhinal area, lateral part, layer 2,32B825
+999,Entorhinal area, lateral part, layer 2/3,32B825
+715,Entorhinal area, lateral part, layer 2a,32B825
+764,Entorhinal area, lateral part, layer 2b,32B825
+52,Entorhinal area, lateral part, layer 3,32B825
+92,Entorhinal area, lateral part, layer 4,32B825
+312,Entorhinal area, lateral part, layer 4/5,32B825
+139,Entorhinal area, lateral part, layer 5,32B825
+387,Entorhinal area, lateral part, layer 5/6,32B825
+28,Entorhinal area, lateral part, layer 6a,32B825
+60,Entorhinal area, lateral part, layer 6b,32B825
+926,Entorhinal area, medial part, dorsal zone,32B825
+526,Entorhinal area, medial part, dorsal zone, layer 1,32B825
+543,Entorhinal area, medial part, dorsal zone, layer 2,32B825
+468,Entorhinal area, medial part, dorsal zone, layer 2a,32B825
+508,Entorhinal area, medial part, dorsal zone, layer 2b,32B825
+664,Entorhinal area, medial part, dorsal zone, layer 3,32B825
+712,Entorhinal area, medial part, dorsal zone, layer 4,32B825
+727,Entorhinal area, medial part, dorsal zone, layer 5,32B825
+550,Entorhinal area, medial part, dorsal zone, layer 5/6,32B825
+743,Entorhinal area, medial part, dorsal zone, layer 6,32B825
+934,Entorhinal area, medial part, ventral zone,32B825
+259,Entorhinal area, medial part, ventral zone, layer 1,32B825
+324,Entorhinal area, medial part, ventral zone, layer 2,32B825
+371,Entorhinal area, medial part, ventral zone, layer 3,32B825
+419,Entorhinal area, medial part, ventral zone, layer 4,32B825
+1133,Entorhinal area, medial part, ventral zone, layer 5/6,32B825
+843,Parasubiculum,72D569
+10693,Parasubiculum, layer 1,72D569
+10694,Parasubiculum, layer 2,72D569
+10695,Parasubiculum, layer 3,72D569
+1037,Postsubiculum,48C83C
+10696,Postsubiculum, layer 1,48C83C
+10697,Postsubiculum, layer 2,48C83C
+10698,Postsubiculum, layer 3,48C83C
+1084,Presubiculum,59B947
+10699,Presubiculum, layer 1,59B947
+10700,Presubiculum, layer 2,59B947
+10701,Presubiculum, layer 3,59B947
+502,Subiculum,4FC244
+509,Subiculum, dorsal part,4FC244
+829,Subiculum, dorsal part, molecular layer,4FC244
+845,Subiculum, dorsal part, pyramidal layer,4BB547
+837,Subiculum, dorsal part, stratum radiatum,4FC244
+518,Subiculum, ventral part,4FC244
+853,Subiculum, ventral part, molecular layer,4FC244
+870,Subiculum, ventral part, pyramidal layer,4BB547
+861,Subiculum, ventral part, stratum radiatum,4FC244
+703,Cortical subplate,8ADA87
+16,Layer 6b, isocortex,8ADA87
+583,Claustrum,8ADA87
+942,Endopiriform nucleus,A0EE9D
+952,Endopiriform nucleus, dorsal part,A0EE9D
+966,Endopiriform nucleus, ventral part,A0EE9D
+131,Lateral amygdalar nucleus,90EB8D
+295,Basolateral amygdalar nucleus,9DE79C
+303,Basolateral amygdalar nucleus, anterior part,9DE79C
+311,Basolateral amygdalar nucleus, posterior part,9DE79C
+451,Basolateral amygdalar nucleus, ventral part,9DE79C
+319,Basomedial amygdalar nucleus,84EA81
+327,Basomedial amygdalar nucleus, anterior part,84EA81
+334,Basomedial amygdalar nucleus, posterior part,84EA81
+780,Posterior amygdalar nucleus,97EC93
+623,Cerebral nuclei,98D6F9
+477,Striatum,98D6F9
+485,Striatum dorsal region,98D6F9
+672,Caudoputamen,98D6F9
+493,Striatum ventral region,80CDF8
+56,Nucleus accumbens,80CDF8
+998,Fundus of striatum,80CDF8
+754,Olfactory tubercle,80CDF8
+481,Islands of Calleja,80CDF8
+489,Major island of Calleja,80CDF8
+144,Olfactory tubercle, layers 1-3,80CDF8
+458,Olfactory tubercle, molecular layer,80CDF8
+465,Olfactory tubercle, pyramidal layer,80CDF8
+473,Olfactory tubercle, polymorph layer,80CDF8
+275,Lateral septal complex,90CBED
+242,Lateral septal nucleus,90CBED
+250,Lateral septal nucleus, caudal (caudodorsal) part,90CBED
+258,Lateral septal nucleus, rostral (rostroventral) part,90CBED
+266,Lateral septal nucleus, ventral part,90CBED
+310,Septofimbrial nucleus,90CBED
+333,Septohippocampal nucleus,90CBED
+278,Striatum-like amygdalar nuclei,80C0E2
+23,Anterior amygdalar area,80C0E2
+292,Bed nucleus of the accessory olfactory tract,80C0E2
+536,Central amygdalar nucleus,80C0E2
+544,Central amygdalar nucleus, capsular part,80C0E2
+551,Central amygdalar nucleus, lateral part,80C0E2
+559,Central amygdalar nucleus, medial part,80C0E2
+1105,Intercalated amygdalar nucleus,80C0E2
+403,Medial amygdalar nucleus,80C0E2
+411,Medial amygdalar nucleus, anterodorsal part,80C0E2
+418,Medial amygdalar nucleus, anteroventral part,80C0E2
+426,Medial amygdalar nucleus, posterodorsal part,80C0E2
+472,Medial amygdalar nucleus, posterodorsal part, sublayer a,80C0E2
+480,Medial amygdalar nucleus, posterodorsal part, sublayer b,80C0E2
+487,Medial amygdalar nucleus, posterodorsal part, sublayer c,80C0E2
+435,Medial amygdalar nucleus, posteroventral part,80C0E2
+803,Pallidum,8599CC
+818,Pallidum, dorsal region,8599CC
+1022,Globus pallidus, external segment,8599CC
+1031,Globus pallidus, internal segment,8599CC
+835,Pallidum, ventral region,A2B1D8
+342,Substantia innominata,A2B1D8
+298,Magnocellular nucleus,A2B1D8
+826,Pallidum, medial region,96A7D3
+904,Medial septal complex,96A7D3
+564,Medial septal nucleus,96A7D3
+596,Diagonal band nucleus,96A7D3
+581,Triangular nucleus of septum,96A7D3
+809,Pallidum, caudal region,B3C0DF
+351,Bed nuclei of the stria terminalis,B3C0DF
+359,Bed nuclei of the stria terminalis, anterior division,B3C0DF
+537,Bed nuclei of the stria terminalis, anterior division, anterolateral area,B3C0DF
+498,Bed nuclei of the stria terminalis, anterior division, anteromedial area,B3C0DF
+505,Bed nuclei of the stria terminalis, anterior division, dorsomedial nucleus,B3C0DF
+513,Bed nuclei of the stria terminalis, anterior division, fusiform nucleus,B3C0DF
+546,Bed nuclei of the stria terminalis, anterior division, juxtacapsular nucleus,B3C0DF
+521,Bed nuclei of the stria terminalis, anterior division, magnocellular nucleus,B3C0DF
+554,Bed nuclei of the stria terminalis, anterior division, oval nucleus,B3C0DF
+562,Bed nuclei of the stria terminalis, anterior division, rhomboid nucleus,B3C0DF
+529,Bed nuclei of the stria terminalis, anterior division, ventral nucleus,B3C0DF
+367,Bed nuclei of the stria terminalis, posterior division,B3C0DF
+569,Bed nuclei of the stria terminalis, posterior division, dorsal nucleus,B3C0DF
+578,Bed nuclei of the stria terminalis, posterior division, principal nucleus,B3C0DF
+585,Bed nuclei of the stria terminalis, posterior division, interfascicular nucleus,B3C0DF
+594,Bed nuclei of the stria terminalis, posterior division, transverse nucleus,B3C0DF
+602,Bed nuclei of the stria terminalis, posterior division, strial extension,B3C0DF
+287,Bed nucleus of the anterior commissure,B3C0DF
+343,Brain stem,FF7080
+1129,Interbrain,FF7080
+549,Thalamus,FF7080
+864,Thalamus, sensory-motor cortex related,FF8084
+637,Ventral group of the dorsal thalamus,FF8084
+629,Ventral anterior-lateral complex of the thalamus,FF8084
+685,Ventral medial nucleus of the thalamus,FF8084
+709,Ventral posterior complex of the thalamus,FF8084
+718,Ventral posterolateral nucleus of the thalamus,FF8084
+725,Ventral posterolateral nucleus of the thalamus, parvicellular part,FF8084
+733,Ventral posteromedial nucleus of the thalamus,FF8084
+741,Ventral posteromedial nucleus of the thalamus, parvicellular part,FF8084
+406,Subparafascicular nucleus,FF8084
+414,Subparafascicular nucleus, magnocellular part,FF8084
+422,Subparafascicular nucleus, parvicellular part,FF8084
+609,Subparafascicular area,FF8084
+1044,Peripeduncular nucleus,FF8084
+1008,Geniculate group, dorsal thalamus,FF8084
+475,Medial geniculate complex,FF8084
+1072,Medial geniculate complex, dorsal part,FF8084
+1079,Medial geniculate complex, ventral part,FF8084
+1088,Medial geniculate complex, medial part,FF8084
+170,Dorsal part of the lateral geniculate complex,FF8084
+856,Thalamus, polymodal association cortex related,FF909F
+138,Lateral group of the dorsal thalamus,FF909F
+218,Lateral posterior nucleus of the thalamus,FF909F
+1020,Posterior complex of the thalamus,FF909F
+1029,Posterior limiting nucleus of the thalamus,FF909F
+325,Suprageniculate nucleus,FF909F
+239,Anterior group of the dorsal thalamus,FF909F
+255,Anteroventral nucleus of thalamus,FF909F
+127,Anteromedial nucleus,FF909F
+1096,Anteromedial nucleus, dorsal part,FF909F
+1104,Anteromedial nucleus, ventral part,FF909F
+64,Anterodorsal nucleus,FF909F
+1120,Interanteromedial nucleus of the thalamus,FF909F
+1113,Interanterodorsal nucleus of the thalamus,FF909F
+155,Lateral dorsal nucleus of thalamus,FF909F
+444,Medial group of the dorsal thalamus,FF909F
+59,Intermediodorsal nucleus of the thalamus,FF909F
+362,Mediodorsal nucleus of thalamus,FF909F
+617,Mediodorsal nucleus of the thalamus, central part,FF909F
+626,Mediodorsal nucleus of the thalamus, lateral part,FF909F
+636,Mediodorsal nucleus of the thalamus, medial part,FF909F
+366,Submedial nucleus of the thalamus,FF909F
+1077,Perireunensis nucleus,FF909F
+571,Midline group of the dorsal thalamus,FF909F
+149,Paraventricular nucleus of the thalamus,FF909F
+15,Parataenial nucleus,FF909F
+181,Nucleus of reunions,FF909F
+51,Intralaminar nuclei of the dorsal thalamus,FF909F
+189,Rhomboid nucleus,FF909F
+599,Central medial nucleus of the thalamus,FF909F
+907,Paracentral nucleus,FF909F
+575,Central lateral nucleus of the thalamus,FF909F
+930,Parafascicular nucleus,FF909F
+262,Reticular nucleus of the thalamus,FF909F
+1014,Geniculate group, ventral thalamus,FF909F
+27,Intergeniculate leaflet of the lateral geniculate complex,FF909F
+178,Ventral part of the lateral geniculate complex,FF909F
+300,Ventral part of the lateral geniculate complex, lateral zone,FF909F
+316,Ventral part of the lateral geniculate complex, medial zone,FF909F
+321,Subgeniculate nucleus,FF909F
+958,Epithalamus,FF909F
+483,Medial habenula,FF909F
+186,Lateral habenula,FF909F
+953,Pineal body,FF909F
+1097,Hypothalamus,E64438
+157,Periventricular zone,FF5D50
+390,Supraoptic nucleus,FF5D50
+332,Accessory supraoptic group,FF5D50
+432,Nucleus circularis,FF5D50
+38,Paraventricular hypothalamic nucleus,FF5D50
+71,Paraventricular hypothalamic nucleus, magnocellular division,FF5D50
+47,Paraventricular hypothalamic nucleus, magnocellular division, anterior magnocellular part,FF5D50
+79,Paraventricular hypothalamic nucleus, magnocellular division, medial magnocellular part,FF5D50
+103,Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part,FF5D50
+652,Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part, lateral zone,FF5D50
+660,Paraventricular hypothalamic nucleus, magnocellular division, posterior magnocellular part, medial zone,FF5D50
+94,Paraventricular hypothalamic nucleus, parvicellular division,FF5D50
+55,Paraventricular hypothalamic nucleus, parvicellular division, anterior parvicellular part,FF5D50
+87,Paraventricular hypothalamic nucleus, parvicellular division, medial parvicellular part, dorsal zone,FF5D50
+110,Paraventricular hypothalamic nucleus, parvicellular division, periventricular part,FF5D50
+30,Periventricular hypothalamic nucleus, anterior part,FF5D50
+118,Periventricular hypothalamic nucleus, intermediate part,FF5D50
+223,Arcuate hypothalamic nucleus,FF5D50
+141,Periventricular region,FF5547
+72,Anterodorsal preoptic nucleus,FF5547
+80,Anterior hypothalamic area,FF5547
+263,Anteroventral preoptic nucleus,FF5547
+272,Anteroventral periventricular nucleus,FF5547
+830,Dorsomedial nucleus of the hypothalamus,FF5547
+668,Dorsomedial nucleus of the hypothalamus, anterior part,FF5547
+676,Dorsomedial nucleus of the hypothalamus, posterior part,FF5547
+684,Dorsomedial nucleus of the hypothalamus, ventral part,FF5547
+452,Median preoptic nucleus,FF5547
+523,Medial preoptic area,FF5547
+763,Vascular organ of the lamina terminalis,FF5547
+914,Posterodorsal preoptic nucleus,FF5547
+1109,Parastrial nucleus,FF5547
+1124,Suprachiasmatic preoptic nucleus,FF5547
+126,Periventricular hypothalamic nucleus, posterior part,FF5547
+133,Periventricular hypothalamic nucleus, preoptic part,FF5547
+347,Subparaventricular zone,FF5547
+286,Suprachiasmatic nucleus,FF5547
+338,Subfornical organ,FF5547
+689,Ventrolateral preoptic nucleus,FF5547
+467,Hypothalamic medial zone,FF4C3E
+88,Anterior hypothalamic nucleus,FF4C3E
+700,Anterior hypothalamic nucleus, anterior part,FF4C3E
+708,Anterior hypothalamic nucleus, central part,FF4C3E
+716,Anterior hypothalamic nucleus, dorsal part,FF4C3E
+724,Anterior hypothalamic nucleus, posterior part,FF4C3E
+331,Mammillary body,FF4C3E
+210,Lateral mammillary nucleus,FF4C3E
+491,Medial mammillary nucleus,FF4C3E
+732,Medial mammillary nucleus, median part,FF4C3E
+525,Supramammillary nucleus,FF4C3E
+1110,Supramammillary nucleus, lateral part,FF4C3E
+1118,Supramammillary nucleus, medial part,FF4C3E
+557,Tuberomammillary nucleus,FF4C3E
+1126,Tuberomammillary nucleus, dorsal part,FF4C3E
+1,Tuberomammillary nucleus, ventral part,FF4C3E
+515,Medial preoptic nucleus,FF4C3E
+740,Medial preoptic nucleus, central part,FF4C3E
+748,Medial preoptic nucleus, lateral part,FF4C3E
+756,Medial preoptic nucleus, medial part,FF4C3E
+980,Dorsal premammillary nucleus,FF4C3E
+1004,Ventral premammillary nucleus,FF4C3E
+63,Paraventricular hypothalamic nucleus, descending division,FF4C3E
+439,Paraventricular hypothalamic nucleus, descending division, dorsal parvicellular part,FF4C3E
+447,Paraventricular hypothalamic nucleus, descending division, forniceal part,FF4C3E
+455,Paraventricular hypothalamic nucleus, descending division, lateral parvicellular part,FF4C3E
+464,Paraventricular hypothalamic nucleus, descending division, medial parvicellular part, ventral zone,FF4C3E
+693,Ventromedial hypothalamic nucleus,FF4C3E
+761,Ventromedial hypothalamic nucleus, anterior part,FF4C3E
+769,Ventromedial hypothalamic nucleus, central part,FF4C3E
+777,Ventromedial hypothalamic nucleus, dorsomedial part,FF4C3E
+785,Ventromedial hypothalamic nucleus, ventrolateral part,FF4C3E
+946,Posterior hypothalamic nucleus,FF4C3E
+290,Hypothalamic lateral zone,F2483B
+194,Lateral hypothalamic area,F2483B
+226,Lateral preoptic area,F2483B
+356,Preparasubthalamic nucleus,F2483B
+364,Parasubthalamic nucleus,F2483B
+173,Retrochiasmatic area,F2483B
+470,Subthalamic nucleus,F2483B
+614,Tuberal nucleus,F2483B
+797,Zona incerta,F2483B
+796,Dopaminergic A13 group,F2483B
+804,Fields of Forel,F2483B
+10671,Median eminence,F2483B
+313,Midbrain,FF64FF
+339,Midbrain, sensory related,FF7AFF
+302,Superior colliculus, sensory related,FF7AFF
+851,Superior colliculus, optic layer,FF7AFF
+842,Superior colliculus, superficial gray layer,FF7AFF
+834,Superior colliculus, zonal layer,FF7AFF
+4,Inferior colliculus,FF7AFF
+811,Inferior colliculus, central nucleus,FF7AFF
+820,Inferior colliculus, dorsal nucleus,FF7AFF
+828,Inferior colliculus, external nucleus,FF7AFF
+580,Nucleus of the brachium of the inferior colliculus,FF7AFF
+271,Nucleus sagulum,FF7AFF
+874,Parabigeminal nucleus,FF7AFF
+460,Midbrain trigeminal nucleus,FF7AFF
+323,Midbrain, motor related,FF90FF
+381,Substantia nigra, reticular part,FF90FF
+749,Ventral tegmental area,FF90FF
+246,Midbrain reticular nucleus, retrorubral area,FF90FF
+128,Midbrain reticular nucleus,FF90FF
+539,Midbrain reticular nucleus, magnocellular part,FF90FF
+548,Midbrain reticular nucleus, magnocellular part, general,FF90FF
+555,Midbrain reticular nucleus, parvicellular part,FF90FF
+294,Superior colliculus, motor related,FF90FF
+26,Superior colliculus, motor related, deep gray layer,FF90FF
+42,Superior colliculus, motor related, deep white layer,FF90FF
+17,Superior colliculus, motor related, intermediate white layer,FF90FF
+10,Superior colliculus, motor related, intermediate gray layer,FF90FF
+494,Superior colliculus, motor related, intermediate gray layer, sublayer a,FF90FF
+503,Superior colliculus, motor related, intermediate gray layer, sublayer b,FF90FF
+511,Superior colliculus, motor related, intermediate gray layer, sublayer c,FF90FF
+795,Periaqueductal gray,FF90FF
+50,Precommissural nucleus,FF90FF
+67,Interstitial nucleus of Cajal,FF90FF
+587,Nucleus of Darkschewitsch,FF90FF
+1100,Pretectal region,FF90FF
+215,Anterior pretectal nucleus,FF90FF
+531,Medial pretectal area,FF90FF
+628,Nucleus of the optic tract,FF90FF
+634,Nucleus of the posterior commissure,FF90FF
+706,Olivary pretectal nucleus,FF90FF
+1061,Posterior pretectal nucleus,FF90FF
+616,Cuneiform nucleus,FF90FF
+214,Red nucleus,FF90FF
+35,Oculomotor nucleus,FF90FF
+975,Edinger-Westphal nucleus,FF90FF
+115,Trochlear nucleus,FF90FF
+757,Ventral tegmental nucleus,FF90FF
+231,Anterior tegmental nucleus,FF90FF
+66,Lateral terminal nucleus of the accessory optic tract,FF90FF
+75,Dorsal terminal nucleus of the accessory optic tract,FF90FF
+58,Medial terminal nucleus of the accessory optic tract,FF90FF
+615,Substantia nigra, lateral part,FF90FF
+348,Midbrain, behavioral state related,FF90FF
+374,Substantia nigra, compact part,FFA6FF
+1052,Pedunculopontine nucleus,FFA6FF
+165,Midbrain raphe nuclei,FFA6FF
+12,Interfascicular nucleus raphe,FFA6FF
+100,Interpeduncular nucleus,FFA6FF
+197,Rostral linear nucleus raphe,FFA6FF
+591,Central linear nucleus raphe,FFA6FF
+872,Dorsal nucleus raphe,FFA6FF
+1065,Hindbrain,FF9B88
+771,Pons,FF9B88
+1132,Pons, sensory related,FFAE6F
+612,Nucleus of the lateral lemniscus,FFAE6F
+82,Nucleus of the lateral lemniscus, dorsal part,FFAE6F
+90,Nucleus of the lateral lemniscus, horizontal part,FFAE6F
+99,Nucleus of the lateral lemniscus, ventral part,FFAE6F
+7,Principal sensory nucleus of the trigeminal,FFAE6F
+867,Parabrachial nucleus,FFAE6F
+123,Koelliker-Fuse subnucleus,FFAE6F
+881,Parabrachial nucleus, lateral division,FFAE6F
+860,Parabrachial nucleus, lateral division, central lateral part,FFAE6F
+868,Parabrachial nucleus, lateral division, dorsal lateral part,FFAE6F
+875,Parabrachial nucleus, lateral division, external lateral part,FFAE6F
+883,Parabrachial nucleus, lateral division, superior lateral part,FFAE6F
+891,Parabrachial nucleus, lateral division, ventral lateral part,FFAE6F
+890,Parabrachial nucleus, medial division,FFAE6F
+899,Parabrachial nucleus, medial division, external medial part,FFAE6F
+915,Parabrachial nucleus, medial division, medial medial part,FFAE6F
+923,Parabrachial nucleus, medial division, ventral medial part,FFAE6F
+398,Superior olivary complex,FFAE6F
+122,Superior olivary complex, periolivary region,FFAE6F
+105,Superior olivary complex, medial part,FFAE6F
+114,Superior olivary complex, lateral part,FFAE6F
+987,Pons, motor related,FFBA86
+280,Barrington's nucleus,FFBA86
+880,Dorsal tegmental nucleus,FFBA86
+283,Lateral tegmental nucleus,FFBA86
+898,Pontine central gray,FFBA86
+931,Pontine gray,FFBA86
+1093,Pontine reticular nucleus, caudal part,FFBA86
+552,Pontine reticular nucleus, ventral part,FFBA86
+318,Supragenual nucleus,FFBA86
+462,Superior salivatory nucleus,FFBA86
+534,Supratrigeminal nucleus,FFBA86
+574,Tegmental reticular nucleus,FFBA86
+621,Motor nucleus of trigeminal,FFBA86
+1117,Pons, behavioral state related,FFC395
+679,Superior central nucleus raphe,FFC395
+137,Superior central nucleus raphe, lateral part,FFC395
+130,Superior central nucleus raphe, medial part,FFC395
+147,Locus ceruleus,FFC395
+162,Laterodorsal tegmental nucleus,FFC395
+604,Nucleus incertus,FFC395
+146,Pontine reticular nucleus,FFC395
+238,Nucleus raphe pontis,FFC395
+350,Subceruleus nucleus,FFC395
+358,Sublaterodorsal nucleus,FFC395
+354,Medulla,FF9BCD
+386,Medulla, sensory related,FFA5D2
+207,Area postrema,FFA5D2
+607,Cochlear nuclei,FFA5D2
+112,Granular lamina of the cochlear nuclei,FFA5D2
+560,Cochlear nucleus, subpedunclular granular region,FFA5D2
+96,Dorsal cochlear nucleus,FFA5D2
+101,Ventral cochlear nucleus,FFA5D2
+720,Dorsal column nuclei,FFA5D2
+711,Cuneate nucleus,FFA5D2
+1039,Gracile nucleus,FFA5D2
+903,External cuneate nucleus,FFA5D2
+642,Nucleus of the trapezoid body,FFA5D2
+651,Nucleus of the solitary tract,FFA5D2
+659,Nucleus of the solitary tract, central part,FFA5D2
+666,Nucleus of the solitary tract, commissural part,FFA5D2
+674,Nucleus of the solitary tract, gelatinous part,FFA5D2
+682,Nucleus of the solitary tract, lateral part,FFA5D2
+691,Nucleus of the solitary tract, medial part,FFA5D2
+429,Spinal nucleus of the trigeminal, caudal part,FFA5D2
+437,Spinal nucleus of the trigeminal, interpolar part,FFA5D2
+445,Spinal nucleus of the trigeminal, oral part,FFA5D2
+77,Spinal nucleus of the trigeminal, oral part, caudal dorsomedial part,FFA5D2
+53,Spinal nucleus of the trigeminal, oral part, middle dorsomedial part, dorsal zone,FFA5D2
+61,Spinal nucleus of the trigeminal, oral part, middle dorsomedial part, ventral zone,FFA5D2
+45,Spinal nucleus of the trigeminal, oral part, rostral dorsomedial part,FFA5D2
+69,Spinal nucleus of the trigeminal, oral part, ventrolateral part,FFA5D2
+789,Nucleus z,FFA5D2
+370,Medulla, motor related,FFB3D9
+653,Abducens nucleus,FFB3D9
+568,Accessory abducens nucleus,FFB3D9
+661,Facial motor nucleus,FFB3D9
+576,Accessory facial motor nucleus,FFB3D9
+640,Efferent vestibular nucleus,FFB3D9
+135,Nucleus ambiguus,FFB3D9
+939,Nucleus ambiguus, dorsal division,FFB3D9
+143,Nucleus ambiguus, ventral division,FFB3D9
+839,Dorsal motor nucleus of the vagus nerve,FFB3D9
+887,Efferent cochlear group,FFB3D9
+1048,Gigantocellular reticular nucleus,FFB3D9
+372,Infracerebellar nucleus,FFB3D9
+83,Inferior olivary complex,FFB3D9
+136,Intermediate reticular nucleus,FFB3D9
+106,Inferior salivatory nucleus,FFB3D9
+203,Linear nucleus of the medulla,FFB3D9
+235,Lateral reticular nucleus,FFB3D9
+955,Lateral reticular nucleus, magnocellular part,FFB3D9
+963,Lateral reticular nucleus, parvicellular part,FFB3D9
+307,Magnocellular reticular nucleus,FFB3D9
+395,Medullary reticular nucleus,FFB3D9
+1098,Medullary reticular nucleus, dorsal part,FFB3D9
+1107,Medullary reticular nucleus, ventral part,FFB3D9
+852,Parvicellular reticular nucleus,FFB3D9
+859,Parasolitary nucleus,FFB3D9
+938,Paragigantocellular reticular nucleus,FFB3D9
+970,Paragigantocellular reticular nucleus, dorsal part,FFB3D9
+978,Paragigantocellular reticular nucleus, lateral part,FFB3D9
+154,Perihypoglossal nuclei,FFB3D9
+161,Nucleus intercalatus,FFB3D9
+177,Nucleus of Roller,FFB3D9
+169,Nucleus prepositus,FFB3D9
+995,Paramedian reticular nucleus,FFB3D9
+1069,Parapyramidal nucleus,FFB3D9
+185,Parapyramidal nucleus, deep part,FFB3D9
+193,Parapyramidal nucleus, superficial part,FFB3D9
+701,Vestibular nuclei,FFB3D9
+209,Lateral vestibular nucleus,FFB3D9
+202,Medial vestibular nucleus,FFB3D9
+225,Spinal vestibular nucleus,FFB3D9
+217,Superior vestibular nucleus,FFB3D9
+765,Nucleus x,FFB3D9
+773,Hypoglossal nucleus,FFB3D9
+781,Nucleus y,FFB3D9
+76,Interstitial nucleus of the vestibular nerve,FFB3D9
+379,Medulla, behavioral state related,FFC6E2
+206,Nucleus raphe magnus,FFC6E2
+230,Nucleus raphe pallidus,FFC6E2
+222,Nucleus raphe obscurus,FFC6E2
+512,Cerebellum,F0F080
+528,Cerebellar cortex,F0F080
+645,Vermal regions,FFFC91
+912,Lingula (I),FFFC91
+10707,Lingula (I), molecular layer,FFFC91
+10706,Lingula (I), Purkinje layer,FFFC91
+10705,Lingula (I), granular layer,ECE754
+920,Central lobule,FFFC91
+976,Lobule II,FFFC91
+10710,Lobule II, molecular layer,FFFC91
+10709,Lobule II, Purkinje layer,FFFC91
+10708,Lobule II, granular layer,ECE754
+984,Lobule III,FFFC91
+10713,Lobule III, molecular layer,FFFC91
+10712,Lobule III, Purkinje layer,FFFC91
+10711,Lobule III, granular layer,ECE754
+928,Culmen,FFFC91
+992,Lobule IV,FFFC91
+10716,Lobule IV, molecular layer,FFFC91
+10715,Lobule IV, Purkinje layer,FFFC91
+10714,Lobule IV, granular layer,ECE754
+1001,Lobule V,FFFC91
+10719,Lobule V, molecular layer,FFFC91
+10718,Lobule V, Purkinje layer,FFFC91
+10717,Lobule V, granular layer,ECE754
+1091,Lobules IV-V,FFFC91
+10722,Lobules IV-V, molecular layer,FFFC91
+10721,Lobules IV-V, Purkinje layer,FFFC91
+10720,Lobules IV-V, granular layer,ECE754
+936,Declive (VI),FFFC91
+10725,Declive (VI), molecular layer,FFFC91
+10724,Declive (VI), Purkinje layer,FFFC91
+10723,Declive (VI), granular layer,ECE754
+944,Folium-tuber vermis (VII),FFFC91
+10728,Folium-tuber vermis (VII), molecular layer,FFFC91
+10727,Folium-tuber vermis (VII), Purkinje layer,FFFC91
+10726,Folium-tuber vermis (VII), granular layer,ECE754
+951,Pyramus (VIII),FFFC91
+10731,Pyramus (VIII), molecular layer,FFFC91
+10730,Pyramus (VIII), Purkinje layer,FFFC91
+10729,Pyramus (VIII), granular layer,ECE754
+957,Uvula (IX),FFFC91
+10734,Uvula (IX), molecular layer,FFFC91
+10733,Uvula (IX), Purkinje layer,FFFC91
+10732,Uvula (IX), granular layer,ECE754
+968,Nodulus (X),FFFC91
+10737,Nodulus (X), molecular layer,FFFC91
+10736,Nodulus (X), Purkinje layer,FFFC91
+10735,Nodulus (X), granular layer,ECE754
+1073,Hemispheric regions,FFFC91
+1007,Simple lobule,FFFC91
+10674,Simple lobule, molecular layer,FFFC91
+10673,Simple lobule, Purkinje layer,FFFC91
+10672,Simple lobule, granular layer,ECE754
+1017,Ansiform lobule,FFFC91
+1056,Crus 1,FFFC91
+10677,Crus 1, molecular layer,FFFC91
+10676,Crus 1, Purkinje layer,FFFC91
+10675,Crus 1, granular layer,ECE754
+1064,Crus 2,FFFC91
+10680,Crus 2, molecular layer,FFFC91
+10679,Crus 2, Purkinje layer,FFFC91
+10678,Crus 2, granular layer,ECE754
+1025,Paramedian lobule,FFFC91
+10683,Paramedian lobule, molecular layer,FFFC91
+10682,Paramedian lobule, Purkinje layer,FFFC91
+10681,Paramedian lobule, granular layer,ECE754
+1033,Copula pyramidis,FFFC91
+10686,Copula pyramidis, molecular layer,FFFC91
+10685,Copula pyramidis, Purkinje layer,FFFC91
+10684,Copula pyramidis, granular layer,ECE754
+1041,Paraflocculus,FFFC91
+10689,Paraflocculus, molecular layer,FFFC91
+10688,Paraflocculus, Purkinje layer,FFFC91
+10687,Paraflocculus, granular layer,ECE754
+1049,Flocculus,FFFC91
+10692,Flocculus, molecular layer,FFFC91
+10691,Flocculus, Purkinje layer,FFFC91
+10690,Flocculus, granular layer,ECE754
+1144,Cerebellar cortex, molecular layer,FFFC91
+1145,Cerebellar cortex, Purkinje layer,FFFC91
+1143,Cerebellar cortex, granular layer,ECE754
+519,Cerebellar nuclei,F0F080
+989,Fastigial nucleus,FFFDBC
+91,Interposed nucleus,FFFDBC
+846,Dentate nucleus,FFFDBC
+1009,fiber tracts,CCCCCC
+967,cranial nerves,CCCCCC
+885,terminal nerve,CCCCCC
+949,vomeronasal nerve,CCCCCC
+840,olfactory nerve,CCCCCC
+1016,olfactory nerve layer of main olfactory bulb,CCCCCC
+21,lateral olfactory tract, general,CCCCCC
+665,lateral olfactory tract, body,CCCCCC
+538,dorsal limb,CCCCCC
+459,accessory olfactory tract,CCCCCC
+900,anterior commissure, olfactory limb,CCCCCC
+848,optic nerve,CCCCCC
+876,accessory optic tract,CCCCCC
+916,brachium of the superior colliculus,CCCCCC
+336,superior colliculus commissure,CCCCCC
+117,optic chiasm,CCCCCC
+125,optic tract,CCCCCC
+357,tectothalamic pathway,CCCCCC
+832,oculomotor nerve,CCCCCC
+62,medial longitudinal fascicle,CCCCCC
+158,posterior commissure,CCCCCC
+911,trochlear nerve,CCCCCC
+384,trochlear nerve decussation,CCCCCC
+710,abducens nerve,CCCCCC
+901,trigeminal nerve,CCCCCC
+93,motor root of the trigeminal nerve,CCCCCC
+229,sensory root of the trigeminal nerve,CCCCCC
+705,midbrain tract of the trigeminal nerve,CCCCCC
+794,spinal tract of the trigeminal nerve,CCCCCC
+798,facial nerve,CCCCCC
+1131,intermediate nerve,CCCCCC
+1116,genu of the facial nerve,CCCCCC
+933,vestibulocochlear nerve,CCCCCC
+1076,efferent cochleovestibular bundle,CCCCCC
+413,vestibular nerve,CCCCCC
+948,cochlear nerve,CCCCCC
+841,trapezoid body,CCCCCC
+641,intermediate acoustic stria,CCCCCC
+506,dorsal acoustic stria,CCCCCC
+658,lateral lemniscus,CCCCCC
+633,inferior colliculus commissure,CCCCCC
+482,brachium of the inferior colliculus,CCCCCC
+808,glossopharyngeal nerve,CCCCCC
+917,vagus nerve,CCCCCC
+237,solitary tract,CCCCCC
+717,accessory spinal nerve,CCCCCC
+813,hypoglossal nerve,CCCCCC
+925,ventral roots,CCCCCC
+792,dorsal roots,CCCCCC
+932,cervicothalamic tract,CCCCCC
+570,dorsolateral fascicle,CCCCCC
+522,dorsal commissure of the spinal cord,CCCCCC
+858,ventral commissure of the spinal cord,CCCCCC
+586,fasciculus proprius,CCCCCC
+514,dorsal column,CCCCCC
+380,cuneate fascicle,CCCCCC
+388,gracile fascicle,CCCCCC
+396,internal arcuate fibers,CCCCCC
+697,medial lemniscus,CCCCCC
+871,spinothalamic tract,CCCCCC
+29,lateral spinothalamic tract,CCCCCC
+389,ventral spinothalamic tract,CCCCCC
+245,spinocervical tract,CCCCCC
+261,spino-olivary pathway,CCCCCC
+270,spinoreticular pathway,CCCCCC
+293,spinovestibular pathway,CCCCCC
+277,spinotectal pathway,CCCCCC
+253,spinohypothalamic pathway,CCCCCC
+285,spinotelenchephalic pathway,CCCCCC
+627,hypothalamohypophysial tract,CCCCCC
+960,cerebellum related fiber tracts,CCCCCC
+744,cerebellar commissure,CCCCCC
+752,cerebellar peduncles,CCCCCC
+326,superior cerebelar peduncles,CCCCCC
+812,superior cerebellar peduncle decussation,CCCCCC
+85,spinocerebellar tract,CCCCCC
+850,uncinate fascicle,CCCCCC
+866,ventral spinocerebellar tract,CCCCCC
+78,middle cerebellar peduncle,CCCCCC
+1123,inferior cerebellar peduncle,CCCCCC
+553,dorsal spinocerebellar tract,CCCCCC
+499,cuneocerebellar tract,CCCCCC
+650,juxtarestiform body,CCCCCC
+490,bulbocerebellar tract,CCCCCC
+404,olivocerebellar tract,CCCCCC
+410,reticulocerebellar tract,CCCCCC
+373,trigeminocerebellar tract,CCCCCC
+728,arbor vitae,CCCCCC
+983,lateral forebrain bundle system,CCCCCC
+776,corpus callosum,CCCCCC
+956,corpus callosum, anterior forceps,CCCCCC
+579,external capsule,CCCCCC
+964,corpus callosum, extreme capsule,CCCCCC
+1108,genu of corpus callosum,CCCCCC
+971,corpus callosum, posterior forceps,CCCCCC
+979,corpus callosum, rostrum,CCCCCC
+986,corpus callosum, splenium,CCCCCC
+784,corticospinal tract,CCCCCC
+6,internal capsule,CCCCCC
+924,cerebal peduncle,CCCCCC
+1036,corticotectal tract,CCCCCC
+1012,corticorubral tract,CCCCCC
+1003,corticopontine tract,CCCCCC
+994,corticobulbar tract,CCCCCC
+190,pyramid,CCCCCC
+198,pyramidal decussation,CCCCCC
+1019,corticospinal tract, crossed,CCCCCC
+1028,corticospinal tract, uncrossed,CCCCCC
+896,thalamus related,CCCCCC
+1092,external medullary lamina of the thalamus,CCCCCC
+14,internal medullary lamina of the thalamus,CCCCCC
+86,middle thalamic commissure,CCCCCC
+365,thalamic peduncles,CCCCCC
+1000,extrapyramidal fiber systems,CCCCCC
+760,cerebral nuclei related,CCCCCC
+142,pallidothalmic pathway,CCCCCC
+102,nigrostriatal tract,CCCCCC
+109,nigrothalamic fibers,CCCCCC
+134,pallidotegmental fascicle,CCCCCC
+309,striatonigral pathway,CCCCCC
+317,subthalamic fascicle,CCCCCC
+877,tectospinal pathway,CCCCCC
+1051,direct tectospinal pathway,CCCCCC
+1060,doral tegmental decussation,CCCCCC
+1043,crossed tectospinal pathway,CCCCCC
+863,rubrospinal tract,CCCCCC
+397,ventral tegmental decussation,CCCCCC
+221,rubroreticular tract,CCCCCC
+736,central tegmental bundle,CCCCCC
+855,retriculospinal tract,CCCCCC
+205,retriculospinal tract, lateral part,CCCCCC
+213,retriculospinal tract, medial part,CCCCCC
+941,vestibulospinal pathway,CCCCCC
+991,medial forebrain bundle system,CCCCCC
+768,cerebrum related,CCCCCC
+884,amygdalar capsule,CCCCCC
+892,ansa peduncularis,CCCCCC
+908,anterior commissure, temporal limb,CCCCCC
+940,cingulum bundle,CCCCCC
+1099,fornix system,CCCCCC
+466,alveus,CCCCCC
+530,dorsal fornix,CCCCCC
+603,fimbria,CCCCCC
+745,precommissural fornix, general,CCCCCC
+420,precommissural fornix diagonal band,CCCCCC
+737,postcommissural fornix,CCCCCC
+428,medial corticohypothalmic tract,CCCCCC
+436,columns of the fornix,CCCCCC
+618,hippocampal commissures,CCCCCC
+443,dorsal hippocampal commissure,CCCCCC
+449,ventral hippocampal commissure,CCCCCC
+713,perforant path,CCCCCC
+474,angular path,CCCCCC
+37,longitudinal association bundle,CCCCCC
+301,stria terminalis,CCCCCC
+824,hypothalamus related,CCCCCC
+54,medial forebrain bundle,CCCCCC
+405,ventrolateral hypothalamic tract,CCCCCC
+174,preoptic commissure,CCCCCC
+349,supraoptic commissures,CCCCCC
+817,supraoptic commissures, anterior,CCCCCC
+825,supraoptic commissures, dorsal,CCCCCC
+833,supraoptic commissures, ventral,CCCCCC
+166,premammillary commissure,CCCCCC
+341,supramammillary decussation,CCCCCC
+182,propriohypothalamic pathways,CCCCCC
+762,propriohypothalamic pathways, dorsal,CCCCCC
+770,propriohypothalamic pathways, lateral,CCCCCC
+779,propriohypothalamic pathways, medial,CCCCCC
+787,propriohypothalamic pathways, ventral,CCCCCC
+150,periventricular bundle of the hypothalamus,CCCCCC
+46,mammillary related,CCCCCC
+753,principal mammillary tract,CCCCCC
+690,mammilothalmic tract,CCCCCC
+681,mammillotegmental tract,CCCCCC
+673,mammillary peduncle,CCCCCC
+1068,dorsal thalamus related,CCCCCC
+722,periventricular bundle of the thalamus,CCCCCC
+1083,epithalamus related,CCCCCC
+802,stria medullaris,CCCCCC
+595,fasciculus retroflexus,CCCCCC
+611,habenular commissure,CCCCCC
+730,pineal stalk,CCCCCC
+70,midbrain related,CCCCCC
+547,dorsal longitudinal fascicle,CCCCCC
+563,dorsal tegmental tract,CCCCCC
+73,ventricular systems,AAAAAA
+81,lateral ventricle,AAAAAA
+89,rhinocele,AAAAAA
+98,subependymal zone,AAAAAA
+108,choroid plexus,AAAAAA
+116,choroid fissure,AAAAAA
+124,interventricular foramen,AAAAAA
+129,third ventricle,AAAAAA
+140,cerebral aqueduct,AAAAAA
+145,fourth ventricle,AAAAAA
+153,lateral recess,AAAAAA
+164,central canal, spinal cord/medulla,AAAAAA
+1024,grooves,AAAAAA
+1032,grooves of the cerebral cortex,AAAAAA
+1055,endorhinal groove,AAAAAA
+1063,hippocampal fissure,AAAAAA
+1071,rhinal fissure,AAAAAA
+1078,rhinal incisure,AAAAAA
+1040,grooves of the cerebellar cortex,AAAAAA
+1087,precentral fissure,AAAAAA
+1095,preculminate fissure,AAAAAA
+1103,primary fissure,AAAAAA
+1112,posterior superior fissure,AAAAAA
+1119,prepyramidal fissure,AAAAAA
+3,secondary fissure,AAAAAA
+11,posterolateral fissure,AAAAAA
+18,nodular fissure,AAAAAA
+25,simple fissure,AAAAAA
+34,intercrural fissure,AAAAAA
+43,ansoparamedian fissure,AAAAAA
+49,intraparafloccular fissure,AAAAAA
+57,paramedian sulcus,AAAAAA
+65,parafloccular sulcus,AAAAAA
+624,Interpeduncular fossa,AAAAAA
+304325711,retina,7F2E7E
 '''

--- a/pipeline/report.py
+++ b/pipeline/report.py
@@ -388,6 +388,20 @@ class ProbeLevelPhotostimEffectReport(dj.Computed):
         plt.close('all')
         self.insert1({**key, **fig_dict})
 
+
+@schema
+class ProbeLevelDriftMap(dj.Computed):
+    definition = """
+    -> ephys.ProbeInsertion
+    -> ephys.ClusteringMethod
+    ---
+    driftmap: filepath@report_store
+    """
+
+    def make(self, key):
+        pass
+
+
 # ============================= UNIT LEVEL ====================================
 
 


### PR DESCRIPTION
Required changes to table definition:

Add 2 attributes to the `Unit` table:
```
    spike_sites : longblob  # array of electrode associated with each spike
    spike_depths : longblob # (um) array of depths associated with each spike
```

Add 2 attributes to the `ArchivedClustering.Unit` table:
```
        spike_sites : blob@archive_store  # array of electrode associated with each spike
        spike_depths : blob@archive_store # (um) array of depths associated with each spike
```

Add 2 attributes to the `ccf.CCFAnnotation` table:
```
@schema
class CCFAnnotation(dj.Manual):
    definition = """
    -> CCF
    -> AnnotationType
    ---
    ontology_region_id: int  
    annotation  : varchar(1024)
    index (annotation)
    color_code: varchar(6) # hexcode of the color code of this region
    """
```

Once tables are updated, running 2 fixes:
+ fix_0010: ingest spike_depths, requires data locally
+ fix_0011: ingest color hexcode