### PR TITLE
behavior ingest: add mock 'reserve_jobs' to populate to assist devel/debug

### DIFF
--- a/pipeline/ingest/behavior.py
+++ b/pipeline/ingest/behavior.py
@@ -195,9 +195,17 @@ class BehaviorIngest(dj.Imported):
         return recs
 
     def populate(self, *args, **kwargs):
+        # 'populate' which won't require upstream tables
+        # 'reserve_jobs' not parallel, overloaded to mean "don't exit on error"
         for k in self.key_source:
-            with dj.conn().transaction:
-                self.make(k)
+            try:
+                with dj.conn().transaction:
+                    self.make(k)
+            except Exception as e:
+                log.warning('session key {} error: {}'.format(
+                    key, repr(e))
+                if not kwargs.get('reserve_jobs', False):
+                    raise
 
     def make(self, key):
         log.info('BehaviorIngest.make(): key: {key}'.format(key=key))
@@ -730,9 +738,17 @@ class BehaviorBpodIngest(dj.Imported):
         return key_source
 
     def populate(self, *args, **kwargs):
+        # 'populate' which won't require upstream tables
+        # 'reserve_jobs' not parallel, overloaded to mean "don't exit on error"
         for k in self.key_source:
-            with dj.conn().transaction:
-                self.make(k)
+            try:
+                with dj.conn().transaction:
+                    self.make(k)
+            except Exception as e:
+                log.warning('session key {} error: {}'.format(
+                    key, repr(e))
+                if not kwargs.get('reserve_jobs', False):
+                    raise
 
     def make(self, key):
         log.info('BehaviorBpodIngest.make(): key: {key}'.format(key=key))

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -84,7 +84,8 @@ def ingest_behavior(*args):
 
 def ingest_foraging_behavior(*args):
     from pipeline.ingest import behavior as behavior_ingest
-    behavior_ingest.BehaviorBpodIngest().populate(display_progress=True)
+    behavior_ingest.BehaviorBpodIngest().populate(
+        display_progress=True, reserve_jobs=True)
 
 
 def ingest_ephys(*args):


### PR DESCRIPTION

implement a fake 'reserve_jobs' in the behavior ingest populate functions
which will emulate the no-exit-on-error behavior of true parallel populate.

this can be set to allow ingest routines to continue to completion to assist
in debugging. If parallel populate is ever implemented, it will retain this
sense.

enable by default for shell 'ingest_foraging_behavior' but not original
'ingest_behavior' - ingest_behavior function shouldn't error as is;
if it does, this means a code bug.