### PR TITLE
pipeline/ccf.py: flip CCF/CCFAnnotation to load from scaled reference 10um stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pillow
 tqdm
 xlrd
 numpy
-pybpod
+pynrrd


### PR DESCRIPTION
labels to initial 20um volume were found to have some quantization errors.

to resolve, reload from 10um volume at 1/2 sampling rate, effectively scaling,
more accurately picking up labels.

fix script not provided as label data is backwards compatible with original
coordinate points & insert performed with skip duplicates=True; extra cleanup
to remove points from the original volume not currently labelled may still be
advised.