### PR TITLE
update behavior ingest to correctly determine PhotostimTrial and AutoWater

### DIFF
--- a/pipeline/experiment.py
+++ b/pipeline/experiment.py
@@ -255,7 +255,7 @@ class BehaviorTrial(dj.Imported):
     -> EarlyLick
     -> Outcome
     auto_water=0: bool  # water given after response-time, regardless of correct/incorrect
-    free_water=0: bool  # "empty" trial with water given
+    free_water=0: bool  # "empty" trial with water given (go-cue not played, no trial structure) 
     """
 
 

--- a/pipeline/export.py
+++ b/pipeline/export.py
@@ -134,7 +134,9 @@ def _export_recording(insert_key, output_dir='./', filename=None, overwrite=Fals
 
     trial_spikes = (ephys.Unit.TrialSpikes & insert_key).fetch(order_by='trial asc')
 
-    behav = (experiment.BehaviorTrial & insert_key).fetch(order_by='trial asc')
+    behav = (experiment.BehaviorTrial & insert_key).aggr(
+        experiment.TrialNote & 'trial_note_type="autolearn"',
+        ..., auto_learn='trial_note', keep_all_rows=True).fetch(order_by='trial asc')
 
     trials = behav['trial']
 
@@ -143,7 +145,7 @@ def _export_recording(insert_key, output_dir='./', filename=None, overwrite=Fals
                'neuron_unit_info', 'neuron_unit_quality_control',
                'behavior_report', 'behavior_early_report',
                'behavior_lick_times', 'behavior_lick_directions',
-               'behavior_is_free_water', 'behavior_is_auto_water',
+               'behavior_is_free_water', 'behavior_is_auto_water', 'behavior_auto_learn',
                'task_trial_type', 'task_stimulation', 'trial_end_time',
                'task_sample_time', 'task_delay_time', 'task_cue_time',
                'tracking', 'histology']
@@ -264,6 +266,14 @@ def _export_recording(insert_key, output_dir='./', filename=None, overwrite=Fals
     print('... behavior_is_auto_water:', end='')
 
     edata['behavior_is_auto_water'] = np.array([i for i in behav['auto_water']])
+
+    print('ok.')
+
+    # behavior_auto_learn
+    # ---------------------
+    print('... behavior_auto_learn:', end='')
+
+    edata['behavior_auto_learn'] = np.array([i or 'n/a' for i in behav['auto_learn']])
 
     print('ok.')
 

--- a/pipeline/fixes/fix_0017_determine_photostim_trial.py
+++ b/pipeline/fixes/fix_0017_determine_photostim_trial.py
@@ -1,0 +1,118 @@
+import os
+import logging
+import pathlib
+from datetime import datetime
+from decimal import Decimal
+import datajoint as dj
+import re
+
+from pipeline import lab, experiment, ephys, report
+from pipeline.ingest import behavior as behavior_ingest
+from pipeline.fixes import schema, FixHistory
+
+
+os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = "TRUE"
+
+log = logging.getLogger(__name__)
+
+
+"""
+Up to this moment, a trial is tagged as a photostim trial based on a single criterion:
+    SessionData.StimTrial > 0 
+    
+However, in fact, whether a trial undergo photostim or not also depends on 3 other criteria,
+in all, the following logic would accurately capture the photostim status of a trial:
+
+```
+TrialshadRealPhotoStim = (SessionData.StimTrials(i) > 0 && SessionData.TrialSettings(i).GUI.DelayPeriod == 1.2 && ...
+    SessionData.TrialSettings(i).GUI.ProtocolType ==5 && SessionData.TrialSettings(i).GUI.Autolearn == 4) 
+```
+
+In other word:
++ SessionData.StimTrial > 0 
++ The duration of the delay period is 1.2 sec
++ Trial's protocol == 5 (for Rig2) or > 4 (for Rig3)
++ Autolearn == 4
+
+This fix goes through each trial currently labeled as photostim trial,
+ re-assess and remove from the PhotostimTrial table if those criteria are not met
+"""
+
+
+@schema
+class FixPhotostimTrial(dj.Manual):
+    """
+    This table accompanies fix_0013, keeping track of the units with waveform fixed.
+    This tracking is not extremely important, as a rerun of this fix_0013 will still yield the correct results
+    """
+    definition = """ # This table accompanies fix_0013
+    -> FixHistory
+    -> experiment.SessionTrial
+    ---
+    is_removed: bool
+    """
+
+
+def fix_photostim_trial(session_keys={}):
+    """
+
+    """
+    sessions_2_update = (experiment.Session & experiment.PhotostimTrial & session_keys)
+    sessions_2_update = sessions_2_update - FixPhotostimTrial
+
+    if not sessions_2_update:
+        return
+
+    fix_hist_key = {'fix_name': pathlib.Path(__file__).name,
+                    'fix_timestamp': datetime.now()}
+
+    for key in sessions_2_update.fetch('KEY'):
+        success = _fix_one_session(key)
+        if success:
+            FixHistory.insert1(fix_hist_key, skip_duplicates=True)
+            FixPhotostimTrial.insert([{**fix_hist_key, **ukey, 'fixed': 1} for ukey in (ephys.Unit & key).fetch('KEY')])
+
+
+def _fix_one_session(key):
+    # determine if this session's photostim is: `early-delay` or `late-delay`
+    path = (behavior_ingest.BehaviorIngest.BehaviorFile & key).fetch('behavior_file')[0]
+    h2o = (lab.WaterRestriction & key).fetch1('water_restriction_number')
+
+    photostim_period = 'early-delay'
+    rig_name = re.search('Recording(Rig\d)_', path)
+    if re.match('SC', h2o) and rig_name:
+        rig_name = rig_name.groups()[0]
+        if rig_name == "Rig3":
+            photostim_period = 'late-delay'
+
+    invalid_photostim_trials = []
+    for trial_key in (experiment.PhotostimTrial & key).fetch('KEY'):
+        protocol_type = int((experiment.TrialNote & trial_key
+                             & 'trial_note_type = "protocol #"').fetch1('trial_note'))
+        autolearn = int((experiment.TrialNote & trial_key
+                         & 'trial_note_type = "autolearn"').fetch1('trial_note'))
+
+        if photostim_period == 'early-delay':
+            valid_protocol = protocol_type == 5
+        elif protocol_type == 'late-delay':
+            valid_protocol = protocol_type > 4
+
+        delay_duration = (experiment.TrialEvent & trial_key & 'trial_event_type = "delay"').fetch(
+            'duration', order_by='trial_event_time DESC', limit=1)[0]
+
+        if not (valid_protocol and autolearn == 4 and delay_duration == Decimal('1.2')):
+            # all criteria not met, this trial should not have been a photostim trial
+            invalid_photostim_trials.append(trial_key)
+
+    if len(invalid_photostim_trials):
+        with dj.config(safemode=False):
+            # delete invalid photostim trials
+            (experiment.PhotostimTrial & invalid_photostim_trials).delete()
+            # delete ProbeLevelPhotostimEffectReport figures associated with this session
+            (report.ProbeLevelPhotostimEffectReport & key).delete()
+
+    return True
+
+
+if __name__ == '__main__':
+    fix_photostim_trial()

--- a/pipeline/fixes/fix_0018_auto_water.py
+++ b/pipeline/fixes/fix_0018_auto_water.py
@@ -39,7 +39,7 @@ class FixAutoWater(dj.Manual):
     """
 
 
-def fix_photostim_trial(session_keys={}):
+def fix_autowater_trial(session_keys={}):
     """
 
     """
@@ -103,3 +103,7 @@ def _fix_one_session(key):
                 (experiment.BehaviorTrial & tkey)._update('auto_water', auto_water)
 
     return True, incorrect_autowater_trials
+
+
+if __name__ == '__main__':
+    fix_autowater_trial()

--- a/pipeline/fixes/fix_0018_auto_water.py
+++ b/pipeline/fixes/fix_0018_auto_water.py
@@ -58,8 +58,8 @@ def fix_autowater_trial(session_keys={}):
         if success:
             FixHistory.insert1(fix_hist_key, skip_duplicates=True)
             FixAutoWater.insert([{**fix_hist_key, **tkey,
-                                       'auto_water_needed_fix': 1 if tkey['trial'] in needed_fix_trials else 0}
-                                      for tkey in (experiment.BehaviorTrial & key).fetch('KEY')])
+                                  'auto_water_needed_fix': 1 if tkey['trial'] in needed_fix_trials else 0}
+                                 for tkey in (experiment.BehaviorTrial & key).fetch('KEY')])
 
 
 def _fix_one_session(key):

--- a/pipeline/fixes/fix_0018_auto_water.py
+++ b/pipeline/fixes/fix_0018_auto_water.py
@@ -1,0 +1,105 @@
+import os
+import logging
+import pathlib
+from datetime import datetime
+import datajoint as dj
+import numpy as np
+import scipy.io as spio
+
+from pipeline import lab, experiment, ephys, report
+from pipeline.ingest import behavior as behavior_ingest
+from pipeline.ingest.behavior import get_behavior_paths
+
+from pipeline.fixes import schema, FixHistory
+
+os.environ['DJ_SUPPORT_FILEPATH_MANAGEMENT'] = "TRUE"
+
+log = logging.getLogger(__name__)
+
+"""
+Up to this moment, a the auto-water status of a trial is determined based on a single criterion:
+    SessionData.TrialSettings(i).GUI.AutoWater == 1
+
+However, auto-water is also controlled by the behavior system based on historical performance of the animal for a given trial.
+In particular, the auto-water status is determined also based on:
+    t.settings.GaveFreeReward[0] == 1  # free water given on the right port
+    t.settings.GaveFreeReward[1] == 1  # free water given on the left port
+
+This fix goes through each trial, check and update the auto-water status
+"""
+
+
+@schema
+class FixAutoWater(dj.Manual):
+    definition = """ # This table accompanies fix_0018
+    -> FixHistory
+    -> experiment.BehaviorTrial
+    ---
+    auto_water_needed_fix: bool  # was auto_water for this trial incorrect and needed fix
+    """
+
+
+def fix_photostim_trial(session_keys={}):
+    """
+
+    """
+    sessions_2_update = (experiment.Session & experiment.PhotostimTrial & session_keys)
+    sessions_2_update = sessions_2_update - FixAutoWater
+
+    if not sessions_2_update:
+        return
+
+    fix_hist_key = {'fix_name': pathlib.Path(__file__).name,
+                    'fix_timestamp': datetime.now()}
+
+    for key in sessions_2_update.fetch('KEY'):
+        success, incorrect_autowater_trials = _fix_one_session(key)
+        needed_fix_trials = [t['trial'] for t, _ in incorrect_autowater_trials]
+        if success:
+            FixHistory.insert1(fix_hist_key, skip_duplicates=True)
+            FixAutoWater.insert([{**fix_hist_key, **tkey,
+                                       'auto_water_needed_fix': 1 if tkey['trial'] in needed_fix_trials else 0}
+                                      for tkey in (experiment.BehaviorTrial & key).fetch('KEY')])
+
+
+def _fix_one_session(key):
+    # get filepath of the behavior file for this session - and read the .mat file
+    rel_paths = (behavior_ingest.BehaviorIngest.BehaviorFile & key).fetch('behavior_file')
+    if len(rel_paths) > 1:
+        log.warning('Found multiple behavior files for this session {} (unable to handle this case yet)'.format(key))
+        return False, None
+    else:
+        rel_path = rel_paths[0]
+
+    session = (experiment.Session & key).fetch1()
+    rig_path = [p for r, p, _ in get_behavior_paths() if r == session['rig']]
+
+    if len(rig_path) != 1:
+        log.warning('No behavior data path found for rig: {} (please check "behavior_data_paths" in dj_local_conf)'.format(session['rig']))
+        return False, None
+    else:
+        rig_path = rig_path[0]
+
+    path = pathlib.Path(rig_path) / rel_path
+
+    # extract trial data from behavior file to compare "auto_water" value stored in db
+    skey, rows = behavior_ingest.BehaviorIngest._load(session, path)
+
+    trial_keys, auto_waters = (experiment.BehaviorTrial & key).fetch('KEY', 'auto_water', order_by='trial')
+
+    assert len(trial_keys) == len(rows['behavior_trial'])
+
+    # extract correct "auto_water" status from behavior file, compare to the value stored in db
+    incorrect_autowater_trials = []
+    for tkey, auto_water, behavior_trial_data in zip(trial_keys, auto_waters, rows['behavior_trial']):
+        assert tkey['trial'] == behavior_trial_data['trial']
+        if auto_water != behavior_trial_data['auto_water']:
+            incorrect_autowater_trials.append((tkey, auto_water))
+
+    # transactional update for this session
+    if len(incorrect_autowater_trials):
+        with experiment.BehaviorTrial.connection.transaction:
+            for tkey, auto_water in incorrect_autowater_trials:
+                (experiment.BehaviorTrial & tkey)._update('auto_water', auto_water)
+
+    return True, incorrect_autowater_trials

--- a/pipeline/ingest/behavior.py
+++ b/pipeline/ingest/behavior.py
@@ -274,7 +274,6 @@ class BehaviorIngest(dj.Imported):
         if 'StimTrials' in SessionData._fieldnames:
             log.debug('StimTrials detected in session - will include')
             AllStimTrials = SessionData.StimTrials
-            # TODO - fix - check 4 conditions
             assert(AllStimTrials.shape[0] == AllStateTimestamps.shape[0])
         else:
             log.debug('StimTrials not detected in session - will skip')


### PR DESCRIPTION
This PR addresses the issues raised by Susu (Feb 2021) regarding some PhotostimTrial and AutoWater may have been incorrectly labeled. The PR includes:
1. Update to `BehaviorIngest.make()` routine to capture the correct PhotostimTrial and AutoWater labeling
2. A fix script 0017 to correct for inserted PhotostimTrial 
3. A fix script 0018 to correct for inserted AutoWater (requires re-reading of the behavior files (.mat))
4. Update the .mat export routine to include `AutoLearn`

Pasting Susu's note here for reference:
```
%% Point 1
% At the moment, how stimulation trials are ingested is only based on the
% number in SessionData.StimTrials. This number is equal to isstim, which
% is generated from the beginning for every trials (could be 0-no stim,
% 4-left stim, 5-rights stim, or 6-bi stim). However, photostimulation is
% only turned on under conbinatorial conditions stated below in the bpod
% program. With current ingestion, we have included trials that have no
% photostimulation present and labelled them into stimulation trials. 
% This could be the reason why photostim behavioural effect is less 
% prominent than expected, since we have used some control trials for 
% photostimulation analysis.
% Correction is required and figures on MAP GUI should be updated.
​
i = aGivenTrial
% Under SC_RecordingRig2.m program, stimulation trials mean: 'isStim>0 &&
% S.GUI.DelayPeriod==1.2 && S.GUI.ProtocolType==5 && S.GUI.Autolearn == 4'
​
TrialshadRealPhotoStim = (SessionData.StimTrials(i) > 0 && SessionData.TrialSettings(i).GUI.DelayPeriod == 1.2 && ...
    SessionData.TrialSettings(i).GUI.ProtocolType ==5 && SessionData.TrialSettings(i).GUI.Autolearn == 4) 
​
% Under SC_RecordingRig3.m program, stimulation trials mean: 'isStim>0 &&
% Delay_Duration_iTrial==1.2 && S.GUI.ProtocolType>4 && S.GUI.Autolearn == 4'
​
TrialshadRealPhotoStim = (SessionData.StimTrials(i) > 0 && SessionData.ProbeTrials(i) == 0 && ...
    SessionData.TrialSettings(i).GUI.ProtocolType > 4 && SessionData.TrialSettings(i).GUI.Autolearn == 4) 
​
% for Dave's program and data please correct accordingly
​
%% Point 2
% We should add autolearn and antibias trial labels in datajoint ingestion
% and also in exported files
autolearnTrials = (SessionData.TrialSettings(i).GUI.Autolearn == 1)
antibiasTrials = (SessionData.TrialSettings(i).GUI.Autolearn == 4)
​
%% Point 3
% Autowater is different from free water trials. There are two conditions that
% give autowater, one is when Autowater was selected under the GUI, the other is when
% Freereward is given, automatically based on the Bpod program code, for instance, 
% when ann animal made consecutive mistakes or ignores,
% in both cases water is delievered after the go cue,
% wherease for free water trial there's no go cue sound
% Current pipeline ingestion only takes care of when Autowater was selected
% under the GUI but not when Freereward is given by the program. 
​
% In 'GaveFreeReward', when first column == 1, free water is given on right port, 
% when second column == 1, free water is given on left port
​
AutoWaterTrial = (SessionData.TrialSettings(i).GUI.AutoWater == 1 || SessionData.TrialSettings(i).GaveFreeReward(1) == 1 || SessionData.TrialSettings(i).GaveFreeReward(2) == 1) )
​
% another way to find the trials:
AutoWaterTrial = (SessionData.TrialSettings(i).GUI.AutoWater == 1 || ~isnan(SessionData.RawEvents.Trial{1,i}.States.GiveLeftDrop) || ~isnan(SessionData.RawEvents.Trial{1,i}.States.GiveRightDrop) )
```