### PR TITLE
DNS migration updates to docs/notebooks/etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Visit [here](doc/intro.md) for full documentation of this project
 ## The MAP Navigator
 
 A website dedicated for data browsing and results visualization for MAP project can be accessed at
- [https://map-navigator.datajoint.io/](http://map-navigator.datajoint.io/)
+ [https://navigator.mesoscale-activity-map.org/](http://navigator.mesoscale-activity-map.org/)
 
 
 ## Access via Jupyter Hub
 
 A MAP-dedicated Jupyter Hub can be accessed at
- [https://map-jupyter.datajoint.io/](https://map-jupyter.datajoint.io/)
+ [https://jupyter.mesoscale-activity-map.org/](https://jupyter.mesoscale-activity-map.org/)
 
 Users can sign in using their GitHub account. Please contact chris@vathes.com for database credential if you don't already have one.
 

--- a/dj_local_conf_template.json
+++ b/dj_local_conf_template.json
@@ -1,5 +1,5 @@
 {
-    "database.host": "mesoscale-activity.datajoint.io",
+    "database.host": "datajoint.mesoscale-activity-map.org",
     "database.password": "this-is-a-placeholder",
     "database.user": "bogus-example-user",
     "database.port": 3306,

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -107,7 +107,7 @@ This pipeline features a library of specialized functions for:
 
 This section is dedicated for the running and management of this pipeline, including details for:
 + Setup and launching of workers for automated tasks
-+ Setup and launching of the MAP [Web-GUI](http://map-navigator.datajoint.io/)
++ Setup and launching of the MAP [Web-GUI](http://navigator.mesoscale-activity-map.org/)
 + Database administration
 + AWS resource management
 

--- a/doc/pipeline_architecture.md
+++ b/doc/pipeline_architecture.md
@@ -164,7 +164,7 @@ The `psth.UnitSelectivity` table aggregates the 3 period-selectivity for each un
 ![report](static/pipeline_architecture/report_all.svg)
 
 Tables in the `report` schema are at the leaf level of this pipeline, computing and storing the figures
- used for visualization and reporting (via the [MAP Web GUI](http://map-navigator.datajoint.io/))
+ used for visualization and reporting (via the [MAP Web GUI](http://navigator.mesoscale-activity-map.org/))
 
 As shown in the diagram, report figures are categorized into 4 levels.
 

--- a/notebook/workshop/1_data_browsing_demo.ipynb
+++ b/notebook/workshop/1_data_browsing_demo.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dj.config['database.host'] = 'mesoscale-activity.datajoint.io'"
+    "dj.config['database.host'] = 'datajoint.mesoscale-activity-map.org'"
    ]
   },
   {
@@ -6113,7 +6113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebook/workshop/2_visualization_of_ephys_data.ipynb
+++ b/notebook/workshop/2_visualization_of_ephys_data.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dj.config['database.host'] = 'mesoscale-activity.datajoint.io'"
+    "dj.config['database.host'] = 'datajoint.mesoscale-activity-map.org'"
    ]
   },
   {
@@ -687,7 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebook/workshop/3_visualization_of_behavior.ipynb
+++ b/notebook/workshop/3_visualization_of_behavior.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dj.config['database.host'] = 'mesoscale-activity.datajoint.io'"
+    "dj.config['database.host'] = 'datajoint.mesoscale-activity-map.org'"
    ]
   },
   {
@@ -558,7 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
audited against `git ls-files -z |xargs -0 grep -il datajoint.io` - remaining references are in notebook output cells ; didn't rerun.