### PR TITLE
Fixes for histology ingestion + visualization issue

### DIFF
--- a/pipeline/ccf.py
+++ b/pipeline/ccf.py
@@ -191,7 +191,6 @@ class AnnotatedBrainSurface(dj.Manual):
 
 # ========= HELPER METHODS ======
 _ccf_xyz_max = None
-_ccf_vox_res = None
 
 
 def get_ontology_regions():
@@ -210,10 +209,3 @@ def get_ccf_xyz_max():
                                      ymax='max(ccf_y)',
                                      zmax='max(ccf_z)').fetch1('xmax', 'ymax', 'zmax')
     return _ccf_xyz_max
-
-
-def get_ccf_vox_res():
-    global _ccf_vox_res
-    if _ccf_vox_res is None:
-        _ccf_vox_res = (CCFLabel & 'ccf_label_id = 0').fetch1('ccf_resolution')
-    return _ccf_vox_res

--- a/pipeline/ccf.py
+++ b/pipeline/ccf.py
@@ -190,6 +190,8 @@ class AnnotatedBrainSurface(dj.Manual):
 
 
 # ========= HELPER METHODS ======
+_ccf_xyz_max = None
+_ccf_vox_res = None
 
 
 def get_ontology_regions():
@@ -200,3 +202,18 @@ def get_ontology_regions():
 
     return pd.concat([regions, hexcode], axis=1)
 
+
+def get_ccf_xyz_max():
+    global _ccf_xyz_max
+    if _ccf_xyz_max is None:
+        _ccf_xyz_max = CCFLabel.aggr(CCF, xmax='max(ccf_x)',
+                                     ymax='max(ccf_y)',
+                                     zmax='max(ccf_z)').fetch1('xmax', 'ymax', 'zmax')
+    return _ccf_xyz_max
+
+
+def get_ccf_vox_res():
+    global _ccf_vox_res
+    if _ccf_vox_res is None:
+        _ccf_vox_res = (CCFLabel & 'ccf_label_id = 0').fetch1('ccf_resolution')
+    return _ccf_vox_res

--- a/pipeline/histology.py
+++ b/pipeline/histology.py
@@ -1,7 +1,9 @@
 import datajoint as dj
+import numpy as np
 
-from . import lab, experiment, ccf, ephys
-from . import get_schema_name, dict_to_hash
+from . import lab, experiment, ccf, ephys, get_schema_name
+from pipeline.plot import unit_characteristic_plot
+
 [lab, experiment, ccf, ephys]  # schema imports only
 
 schema = dj.schema(get_schema_name('histology'))
@@ -102,6 +104,37 @@ class LabeledProbeTrack(dj.Manual):
 
 
 @schema
+class InterpolatedShankTrack(dj.Computed):
+    definition = """
+    -> ElectrodeCCFPosition
+    shank: int
+    """
+
+    class Point(dj.Part):
+        definition = """
+        -> master
+        -> ccf.CCF  
+        """
+
+    def make(self, key):
+        probe_insertion = ephys.ProbeInsertion & key
+
+        shanks = probe_insertion.aggr(lab.ElectrodeConfig.Electrode * lab.ProbeType.Electrode,
+                                      shanks='GROUP_CONCAT(DISTINCT shank SEPARATOR ", ")').fetch1('shanks')
+        shanks = np.array(shanks.split(', ')).astype(int)
+
+        shank_points = []
+        for shank in shanks:
+            _, shank_ccfs = retrieve_pseudocoronal_slice(probe_insertion, shank)
+            shank_points.extend([{**key, 'shank': shank, 'ccf_label_id': 0,
+                                  'ccf_x': ml, 'ccf_y': dv, 'ccf_z': ap}
+                                 for ml, dv, ap in shank_ccfs])
+
+        self.insert({**key, 'shank': shank} for shank in shanks)
+        self.Point.insert(shank_points)
+
+
+@schema
 class EphysCharacteristic(dj.Imported):
     definition = """
     -> ephys.ProbeInsertion
@@ -171,3 +204,71 @@ class ArchivedElectrodeHistology(dj.Manual):
         ccf_y: float  # (um)
         ccf_z: float  # (um)    
         """
+
+
+# ====================== HELPER METHODS ======================
+
+
+def retrieve_pseudocoronal_slice(probe_insertion, shank_no=1):
+    """
+    For each shank, retrieve the pseudocoronal slice of the brain that the shank traverses
+    This function returns a tuple of 2 things:
+    1. an array of (CCF_DV, CCF_ML, CCF_AP, color_codes) for all points in the pseudocoronal slice
+    2. an array of (CCF_DV, CCF_ML, CCF_AP) for all points on the interpolated track of the shank
+    """
+    probe_insertion = probe_insertion.proj()
+
+    # ---- Electrode sites ----
+    annotated_electrodes = (lab.ElectrodeConfig.Electrode * lab.ProbeType.Electrode
+                            * ephys.ProbeInsertion
+                            * ElectrodeCCFPosition.ElectrodePosition
+                            & probe_insertion & {'shank': shank_no})
+
+    electrode_coords = np.array(list(zip(*annotated_electrodes.fetch(
+        'ccf_z', 'ccf_y', 'ccf_x', order_by='ccf_y'))))  # (AP, DV, ML)
+    probe_track_coords = np.array(list(zip(*(LabeledProbeTrack.Point
+                                             & probe_insertion & {'shank': shank_no}).fetch(
+        'ccf_z', 'ccf_y', 'ccf_x', order_by='ccf_y'))))
+    coords = np.vstack([electrode_coords, probe_track_coords])
+
+    # ---- linear fit of probe in DV-AP axis ----
+    X = np.asmatrix(np.hstack((np.ones((coords.shape[0], 1)), coords[:, 1][:, np.newaxis])))  # DV
+
+    y = np.asmatrix(coords[:, 0]).T  # AP
+    XtX = X.T * X
+    Xty = X.T * y
+    ap_fit = np.linalg.solve(XtX, Xty)
+
+    y = np.asmatrix(coords[:, 2]).T  # ML
+    XtX = X.T * X
+    Xty = X.T * y
+    ml_fit = np.linalg.solve(XtX, Xty)
+
+    # ---- predict x coordinates ----
+    voxel_res = ccf.get_ccf_vox_res()
+    lr_max, dv_max, _ = ccf.get_ccf_xyz_max()
+
+    dv_coords = np.arange(0, dv_max, voxel_res)
+
+    X2 = np.asmatrix(np.hstack((np.ones((len(dv_coords), 1)), dv_coords[:, np.newaxis])))
+
+    ap_coords = np.array(X2 * ap_fit).flatten().astype(np.int)
+    ml_coords = np.array(X2 * ml_fit).flatten().astype(np.int)
+
+    # round to the nearest voxel resolution
+    ap_coords = (voxel_res * np.round(ap_coords / voxel_res)).astype(np.int)
+    ml_coords = (voxel_res * np.round(ml_coords / voxel_res)).astype(np.int)
+
+    # ---- extract pseudoconoral plane from DB ----
+    q_ccf = ccf.CCFAnnotation * ccf.CCFBrainRegion.proj(..., annotation='region_name')
+    dv_pts, lr_pts, ap_pts, color_codes = (
+            q_ccf & [{'ccf_y': dv, 'ccf_z': ap} for ap, dv in zip(ap_coords, dv_coords)]).fetch(
+        'ccf_y', 'ccf_x', 'ccf_z', 'color_code', order_by='ccf_y')
+
+    # ---- CCF coords for voxels on the interpolated probe/shank track ----
+    coronal_point_cloud = set(zip(lr_pts, dv_pts, ap_pts))  # ML, DV, AP
+    shank_ccfs = np.vstack([(ml, dv, ap)
+                            for dv, ap, ml in zip(dv_coords, ap_coords, ml_coords)
+                            if (ml, dv, ap) in coronal_point_cloud])
+
+    return np.vstack([dv_pts, lr_pts, ap_pts, color_codes]).T, shank_ccfs

--- a/pipeline/histology.py
+++ b/pipeline/histology.py
@@ -275,7 +275,7 @@ def retrieve_pseudocoronal_slice(probe_insertion, shank_no=1):
     ml_fit = np.linalg.solve(XtX, Xty)
 
     # ---- predict x coordinates ----
-    voxel_res = ccf.get_ccf_vox_res()
+    voxel_res = ccf.CCFLabel.CCF_R3_20UM_RESOLUTION
     lr_max, dv_max, _ = ccf.get_ccf_xyz_max()
 
     dv_coords = np.arange(0, dv_max, voxel_res)

--- a/pipeline/plot/unit_characteristic_plot.py
+++ b/pipeline/plot/unit_characteristic_plot.py
@@ -413,7 +413,8 @@ def plot_driftmap(probe_insertion, clustering_method=None, shank_no=1):
     last_electrode_site = np.array([*last_electrode_site]).squeeze()
 
     # CCF position of the brain surface where this shank crosses
-    brain_surface_site = (histology.InterpolatedShankTrack.Point & {'shank': shank_no}).fetch(
+    brain_surface_site = (histology.InterpolatedShankTrack.Point
+                          & probe_insertion & {'shank': shank_no}).fetch(
         'ccf_x', 'ccf_y', 'ccf_z', order_by='ccf_y ASC', limit=1)
     brain_surface_site = np.array([*brain_surface_site]).squeeze()
 

--- a/pipeline/plot/unit_characteristic_plot.py
+++ b/pipeline/plot/unit_characteristic_plot.py
@@ -408,15 +408,13 @@ def plot_driftmap(probe_insertion, clustering_method=None, shank_no=1):
         'y_coord', 'ccf_y', 'color_code', order_by='y_coord DESC')
 
     # CCF position of most ventral recording site
-    last_electrode_site = annotated_electrodes.fetch(
-        'ccf_x', 'ccf_y', 'ccf_z', order_by='ccf_y DESC', limit=1)
-    last_electrode_site = np.array([*last_electrode_site]).squeeze()
-
+    last_electrode_site = np.array((histology.InterpolatedShankTrack.DeepestElectrodePoint
+                                    & probe_insertion & {'shank': shank_no}).fetch1(
+        'ccf_x', 'ccf_y', 'ccf_z'))
     # CCF position of the brain surface where this shank crosses
-    brain_surface_site = (histology.InterpolatedShankTrack.Point
-                          & probe_insertion & {'shank': shank_no}).fetch(
-        'ccf_x', 'ccf_y', 'ccf_z', order_by='ccf_y ASC', limit=1)
-    brain_surface_site = np.array([*brain_surface_site]).squeeze()
+    brain_surface_site = np.array((histology.InterpolatedShankTrack.BrainSurfacePoint
+                                   & probe_insertion & {'shank': shank_no}).fetch1(
+        'ccf_x', 'ccf_y', 'ccf_z'))
 
     # CCF position of most ventral recording site, with respect to the brain surface
     y_ref = -np.linalg.norm(last_electrode_site - brain_surface_site)

--- a/pipeline/plot/unit_characteristic_plot.py
+++ b/pipeline/plot/unit_characteristic_plot.py
@@ -321,7 +321,7 @@ def plot_pseudocoronal_slice(probe_insertion, shank_no=1):
                                              & probe_insertion & {'shank': shank_no}).fetch(
         'ccf_z', 'ccf_y', 'ccf_x', order_by='ccf_y'))))
 
-    voxel_res = ccf.get_ccf_vox_res()
+    voxel_res = ccf.CCFLabel.CCF_R3_20UM_RESOLUTION
     lr_max, dv_max, _ = ccf.get_ccf_xyz_max()
 
     pseudocoronal_points, shank_ccfs = histology.retrieve_pseudocoronal_slice(probe_insertion, shank_no)

--- a/pipeline/plot/unit_characteristic_plot.py
+++ b/pipeline/plot/unit_characteristic_plot.py
@@ -20,8 +20,6 @@ from . import PhotostimError
 
 _plt_xmin = -3
 _plt_xmax = 2
-_ccf_xyz_max = None
-_ccf_vox_res = None
 
 
 def plot_clustering_quality(probe_insertion, clustering_method=None, axs=None):
@@ -311,46 +309,32 @@ def plot_unit_bilateral_photostim_effect(probe_insertion, clustering_method=None
 
 
 def plot_pseudocoronal_slice(probe_insertion, shank_no=1):
-    probe_insertion = probe_insertion.proj()
-
     # ---- Electrode sites ----
     annotated_electrodes = (lab.ElectrodeConfig.Electrode * lab.ProbeType.Electrode
                             * ephys.ProbeInsertion
                             * histology.ElectrodeCCFPosition.ElectrodePosition
                             & probe_insertion & {'shank': shank_no})
 
-    coords = np.array(list(zip(*annotated_electrodes.fetch('ccf_z', 'ccf_y', 'ccf_x'))))  # (AP, DV, ML)
+    electrode_coords = np.array(list(zip(*annotated_electrodes.fetch(
+        'ccf_z', 'ccf_y', 'ccf_x', order_by='ccf_y'))))  # (AP, DV, ML)
+    probe_track_coords = np.array(list(zip(*(histology.LabeledProbeTrack.Point
+                                             & probe_insertion & {'shank': shank_no}).fetch(
+        'ccf_z', 'ccf_y', 'ccf_x', order_by='ccf_y'))))
 
-    # ---- linear fit of probe in DV-AP axis ----
-    X = np.asmatrix(np.hstack((np.ones((coords.shape[0], 1)), coords[:, 1][:, np.newaxis])))  # DV
-    y = np.asmatrix(coords[:, 0]).T  # AP
-    XtX = X.T * X
-    Xty = X.T * y
-    b = np.linalg.solve(XtX, Xty)
+    voxel_res = ccf.get_ccf_vox_res()
+    lr_max, dv_max, _ = ccf.get_ccf_xyz_max()
 
-    # ---- predict x coordinates ----
-    voxel_res = _ccf_vox_res or _get_ccf_vox_res()
-    lr_max, dv_max, _ = _ccf_xyz_max or _get_ccf_xyz_max()
+    pseudocoronal_points, shank_ccfs = histology.retrieve_pseudocoronal_slice(probe_insertion, shank_no)
 
-    dv_coords = np.arange(0, dv_max, voxel_res)
-
-    X2 = np.asmatrix(np.hstack((np.ones((len(dv_coords), 1)), dv_coords[:, np.newaxis])))
-
-    ap_coords = np.array(X2 * b).flatten().astype(np.int)
-
-    # round to the nearest voxel resolution
-    ap_coords = (voxel_res * np.round(ap_coords / voxel_res)).astype(np.int)
-
-    # ---- extract pseudoconoral plane from DB ----
-    q_ccf = ccf.CCFAnnotation * ccf.CCFBrainRegion.proj(..., annotation='region_name')
-    dv_pts, lr_pts, colors = (q_ccf & [{'ccf_y': dv, 'ccf_z': ap}
-                                       for ap, dv in zip(ap_coords, dv_coords)]).fetch(
-        'ccf_y', 'ccf_x', 'color_code')
+    dv_pts, lr_pts, ap_pts, color_codes = pseudocoronal_points.T
+    dv_pts = dv_pts.astype(int)
+    lr_pts = lr_pts.astype(int)
+    color_codes = color_codes.astype(str)
 
     # ---- paint annotation color code ----
     coronal_slice = np.full((dv_max + 1, lr_max + 1, 3), np.nan)
-    for color in set(colors):
-        matched_ind = np.where(colors == color)[0]
+    for color in set(color_codes):
+        matched_ind = np.where(color_codes == color)[0]
         dv_ind = dv_pts[matched_ind]  # rows
         lr_ind = lr_pts[matched_ind]  # cols
         try:
@@ -360,8 +344,19 @@ def plot_pseudocoronal_slice(probe_insertion, shank_no=1):
             continue
         coronal_slice[dv_ind, lr_ind, :] = np.full((len(matched_ind), 3), c_rgb)
 
-    # ---- paint electrode sites on this probe/shank ----
-    coronal_slice[coords[:, 1], coords[:, 2], :] = np.full((coords.shape[0], 3), ImageColor.getcolor("#080808", "RGB"))
+    # ---- paint the interpolated track of this probe/shank in gray ----
+    in_probe_range = np.logical_and(shank_ccfs[:, 1] >= probe_track_coords[:, 1].min(),
+                                    shank_ccfs[:, 1] <= probe_track_coords[:, 1].max())
+    in_electrode_range = np.logical_and(shank_ccfs[:, 1] >= electrode_coords[:, 1].min(),
+                                        shank_ccfs[:, 1] <= electrode_coords[:, 1].max())
+
+    tracks_coords = shank_ccfs[np.logical_and(in_probe_range, ~in_electrode_range), :]
+    coronal_slice[tracks_coords[:, 1], tracks_coords[:, 0], :] = np.full(
+        (tracks_coords.shape[0], 3), ImageColor.getcolor("#FFFFFF", "RGB"))
+
+    # ---- paint electrode sites on this probe/shank in black ----
+    coronal_slice[electrode_coords[:, 1], electrode_coords[:, 2], :] = np.full(
+        (electrode_coords.shape[0], 3), ImageColor.getcolor("#080808", "RGB"))
 
     # ---- downsample the 2D slice to the voxel resolution ----
     coronal_slice = coronal_slice[::voxel_res, ::voxel_res, :]
@@ -374,6 +369,7 @@ def plot_pseudocoronal_slice(probe_insertion, shank_no=1):
     fig, ax = plt.subplots(1, 1)
     ax.imshow(coronal_slice.astype(np.uint8), extent=[0, lr_max, dv_max, 0])
 
+    ax.invert_xaxis()
     ax.set_xticks([])
     ax.set_yticks([])
     ax.spines['right'].set_visible(False)
@@ -386,6 +382,8 @@ def plot_pseudocoronal_slice(probe_insertion, shank_no=1):
 
 def plot_driftmap(probe_insertion, clustering_method=None, shank_no=1):
     probe_insertion = probe_insertion.proj()
+
+    assert histology.InterpolatedShankTrack & probe_insertion
 
     if clustering_method is None:
         try:
@@ -409,9 +407,20 @@ def plot_driftmap(probe_insertion, clustering_method=None, shank_no=1):
     pos_y, ccf_y, color_code = annotated_electrodes.fetch(
         'y_coord', 'ccf_y', 'color_code', order_by='y_coord DESC')
 
-    y_ref = -ccf_y.max()  # CCF position of most ventral recording site
+    # CCF position of most ventral recording site
+    last_electrode_site = annotated_electrodes.fetch(
+        'ccf_x', 'ccf_y', 'ccf_z', order_by='ccf_y DESC', limit=1)
+    last_electrode_site = np.array([*last_electrode_site]).squeeze()
 
-    # ---- spikes ----
+    # CCF position of the brain surface where this shank crosses
+    brain_surface_site = (histology.InterpolatedShankTrack.Point & {'shank': shank_no}).fetch(
+        'ccf_x', 'ccf_y', 'ccf_z', order_by='ccf_y ASC', limit=1)
+    brain_surface_site = np.array([*brain_surface_site]).squeeze()
+
+    # CCF position of most ventral recording site, with respect to the brain surface
+    y_ref = -np.linalg.norm(last_electrode_site - brain_surface_site)
+
+    # ---- spikes ----brain_surface_site
     spike_times, spike_depths = units.fetch('spike_times', 'spike_depths', order_by='unit')
 
     spike_times = np.hstack(spike_times)
@@ -788,18 +797,3 @@ def plot_paired_coding_direction(unit_g1, unit_g2, labels=None, time_period=None
 
 def get_m_scale(shank_count):
     return 1350 - 150*shank_count
-
-
-def _get_ccf_xyz_max():
-    xmax, ymax, zmax = ccf.CCFLabel.aggr(ccf.CCF, xmax='max(ccf_x)', ymax='max(ccf_y)', zmax='max(ccf_z)').fetch1(
-        'xmax', 'ymax', 'zmax')
-    global _ccf_xyz_max
-    _ccf_xyz_max = xmax, ymax, zmax
-    return xmax, ymax, zmax
-
-
-def _get_ccf_vox_res():
-    voxel_res = (ccf.CCFLabel & 'ccf_label_id = 0').fetch1('ccf_resolution')
-    global _ccf_vox_res
-    _ccf_vox_res = voxel_res
-    return voxel_res

--- a/pipeline/report.py
+++ b/pipeline/report.py
@@ -583,7 +583,7 @@ class ProbeLevelDriftMap(dj.Computed):
     """
 
     # Only process ProbeInsertion with Histology and InsertionLocation known
-    key_source = (ephys.ProbeInsertion * ephys.ClusteringMethod & ephys.Unit.proj()) & ephys.ProbeInsertion.InsertionLocation & histology.ElectrodeCCFPosition
+    key_source = (ephys.ProbeInsertion * ephys.ClusteringMethod & ephys.Unit.proj()) & histology.InterpolatedShankTrack
 
     def make(self, key):
         water_res_num, sess_date = get_wr_sessdate(key)

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -320,6 +320,9 @@ def populate_ephys(populate_settings={'reserve_jobs': True, 'display_progress': 
     log.info('ephys.MAPClusterMetric.populate()')
     ephys.MAPClusterMetric.populate(**populate_settings)
 
+    log.info('ephys.MAPClusterMetric.populate()')
+    histology.InterpolatedShankTrack.populate(**populate_settings)
+
 
 def populate_psth(populate_settings={'reserve_jobs': True, 'display_progress': True}):
 


### PR DESCRIPTION
Incorrect voxel resolution was used for some of the recent animals' histology ingest.
Voxel resolution should be read from `site.pos.mmPerPixel` (in the MAT file)

Improve coronal slide visualization
Improve driftmap visualization - show real depth-in-brain of the electrodes on a per-shank basis (from CCF)